### PR TITLE
Add OpenClaw recipe for Neuralwatt inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Get your API key from [portal.neuralwatt.com](https://portal.neuralwatt.com), th
 |-------------|--------------|-------------|
 | [nw-usage](scripts/) | CLI for checking energy usage | `nw-usage` or `nw-usage --tmux` |
 | [Claude Code](recipes/claude-code/) | Anthropic's coding CLI with Neuralwatt models | [Setup guide](recipes/claude-code/README.md) |
+| [OpenClaw](recipes/openclaw/) | Personal AI assistant gateway (Telegram, Discord, WhatsApp, etc.) | [Setup guide](recipes/openclaw/README.md) |
 | [OpenCode](recipes/opencode/) | AI coding agent CLI | [Setup guide](recipes/opencode/README.md) |
 | [llm plugin](plugins/llm-neuralwatt/) | Use Neuralwatt with [simonw/llm](https://llm.datasette.io/) CLI | [Setup guide](plugins/llm-neuralwatt/README.md) |
 | [Neovim](recipes/neovim/) | AI completions + energy monitor | [Setup guide](recipes/neovim/README.md) |
@@ -57,6 +58,7 @@ neuralwatt-tools/
 │   └── llm-neuralwatt/      # pip-installable LLM plugin
 └── recipes/
     ├── claude-code/         # Anthropic's coding CLI setup
+    ├── openclaw/            # Personal AI assistant gateway
     ├── opencode/            # AI coding agent CLI setup
     ├── neovim/              # Energy monitor + AI plugin configs
     └── tmux/                # Statusline integration

--- a/recipes/openclaw/README.md
+++ b/recipes/openclaw/README.md
@@ -30,10 +30,13 @@ openclaw onboard --install-daemon \
   --auth-choice custom-api-key \
   --custom-base-url "https://api.neuralwatt.com/v1" \
   --custom-model-id "Qwen/Qwen3.5-397B-A17B-FP8" \
-  --custom-compatibility openai
+  --custom-compatibility openai \
+  --custom-api-key "$NEURALWATT_API_KEY"
 ```
 
-When prompted, paste your Neuralwatt API key.
+When prompted, paste your Neuralwatt API key (or pass it via `--custom-api-key` as shown above).
+
+> **Note:** The onboard wizard uses conservative defaults (16k context, 4k max output). For the full 128k context window our API supports, use Option B or manually edit `~/.openclaw/openclaw.json` after onboarding to set `contextWindow: 131072` and `maxTokens: 32768`.
 
 ### Option B: Manual config
 
@@ -43,16 +46,28 @@ When prompted, paste your Neuralwatt API key.
 export NEURALWATT_API_KEY="your-api-key-here"
 ```
 
-**2. Edit** `~/.openclaw/openclaw.json` (JSON5, comments allowed):
+**2. Register the API key with OpenClaw** so the gateway service can access it:
+
+```bash
+openclaw config set models.providers.neuralwatt.apiKey \
+  --ref-provider default --ref-source env --ref-id NEURALWATT_API_KEY
+```
+
+> **Why not just put the key in the JSON?** OpenClaw resolves secrets through a ref system, not bare strings. A bare `"apiKey": "NEURALWATT_API_KEY"` is sent literally and will return 401. The ref approach also makes the key available to the systemd gateway service, which doesn't inherit your shell environment.
+
+**3. Edit** `~/.openclaw/openclaw.json` (JSON5, comments allowed):
 
 ```json5
 {
+  gateway: {
+    mode: "local",
+  },
   models: {
     mode: "merge",
     providers: {
       neuralwatt: {
         baseUrl: "https://api.neuralwatt.com/v1",
-        apiKey: "NEURALWATT_API_KEY",
+        // apiKey is set via `openclaw config set` (step 2)
         api: "openai-completions",
         models: [
           {
@@ -78,13 +93,13 @@ export NEURALWATT_API_KEY="your-api-key-here"
 
 A complete example config (with identity and channels) is in [`openclaw.json`](openclaw.json) alongside this README.
 
-**3. Start the gateway:**
+**4. Start the gateway:**
 
 ```bash
 openclaw gateway start
 ```
 
-**4. Verify:**
+**5. Verify:**
 
 ```bash
 openclaw gateway health

--- a/recipes/openclaw/README.md
+++ b/recipes/openclaw/README.md
@@ -63,7 +63,7 @@ openclaw config set models.providers.neuralwatt.apiKey \
     mode: "local",
   },
   models: {
-    mode: "replace",
+    mode: "merge",
     providers: {
       neuralwatt: {
         baseUrl: "https://api.neuralwatt.com/v1",

--- a/recipes/openclaw/README.md
+++ b/recipes/openclaw/README.md
@@ -63,7 +63,7 @@ openclaw config set models.providers.neuralwatt.apiKey \
     mode: "local",
   },
   models: {
-    mode: "merge",
+    mode: "replace",
     providers: {
       neuralwatt: {
         baseUrl: "https://api.neuralwatt.com/v1",

--- a/recipes/openclaw/README.md
+++ b/recipes/openclaw/README.md
@@ -112,14 +112,16 @@ You should see your Neuralwatt model in the list.
 
 OpenClaw supports 20+ messaging channels. The most common ones:
 
-| Channel | Setup |
-|---------|-------|
-| Web UI | Built-in at `http://localhost:18789` |
-| Telegram | Add `channels.telegram.token` in config |
-| Discord | Add `channels.discord.token` in config |
-| WhatsApp | Add `channels.whatsapp.allowFrom` and scan QR |
+| Channel | Setup | Docs |
+|-|-|-|
+| Web UI | Built-in at `http://localhost:18789` | — |
+| Telegram | Add `channels.telegram.token` in config | [telegram.md](https://github.com/openclaw/openclaw/blob/main/docs/channels/telegram.md) |
+| Discord | Add `channels.discord.token` in config | [discord.md](https://github.com/openclaw/openclaw/blob/main/docs/channels/discord.md) |
+| WhatsApp | Add `channels.whatsapp.allowFrom` and scan QR | [whatsapp.md](https://github.com/openclaw/openclaw/blob/main/docs/channels/whatsapp.md) |
+| Slack | Add `channels.slack.token` in config | [slack.md](https://github.com/openclaw/openclaw/blob/main/docs/channels/slack.md) |
+| Signal | Add `channels.signal` config | [signal.md](https://github.com/openclaw/openclaw/blob/main/docs/channels/signal.md) |
 
-See the [OpenClaw channel docs](https://github.com/openclaw/openclaw/tree/main/docs/channels) for full setup instructions per channel.
+See the [full channel list](https://github.com/openclaw/openclaw/tree/main/docs/channels) and [OpenClaw docs](https://docs.openclaw.ai) for more.
 
 ## Available Models
 

--- a/recipes/openclaw/README.md
+++ b/recipes/openclaw/README.md
@@ -1,0 +1,136 @@
+# OpenClaw with Neuralwatt
+
+[OpenClaw](https://github.com/openclaw/openclaw) is a personal AI assistant gateway that connects to messaging platforms (Telegram, Discord, WhatsApp, Slack, and more) and runs your choice of model behind it. Since Neuralwatt exposes an OpenAI-compatible API, OpenClaw can use it as a provider with a few lines of config.
+
+## Prerequisites
+
+- [Neuralwatt API key](https://portal.neuralwatt.com)
+- Node.js 22.16+ (Node 24 recommended)
+
+## Install
+
+```bash
+curl -fsSL https://openclaw.ai/install.sh | bash
+```
+
+Or via npm:
+
+```bash
+npm install -g openclaw@latest
+```
+
+## Setup
+
+### Option A: Interactive onboarding
+
+The fastest path. OpenClaw's onboard wizard handles provider setup, API key, and channel configuration in one go:
+
+```bash
+openclaw onboard --install-daemon \
+  --auth-choice custom-api-key \
+  --custom-base-url "https://api.neuralwatt.com/v1" \
+  --custom-model-id "Qwen/Qwen3.5-397B-A17B-FP8" \
+  --custom-compatibility openai
+```
+
+When prompted, paste your Neuralwatt API key.
+
+### Option B: Manual config
+
+**1. Export your API key** (add to `~/.zshrc`):
+
+```bash
+export NEURALWATT_API_KEY="your-api-key-here"
+```
+
+**2. Edit** `~/.openclaw/openclaw.json` (JSON5, comments allowed):
+
+```json5
+{
+  models: {
+    mode: "merge",
+    providers: {
+      neuralwatt: {
+        baseUrl: "https://api.neuralwatt.com/v1",
+        apiKey: "NEURALWATT_API_KEY",
+        api: "openai-completions",
+        models: [
+          {
+            id: "Qwen/Qwen3.5-397B-A17B-FP8",
+            name: "Qwen3.5 397B",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 131072,
+            maxTokens: 32768,
+          },
+        ],
+      },
+    },
+  },
+  agents: {
+    defaults: {
+      model: { primary: "neuralwatt/Qwen/Qwen3.5-397B-A17B-FP8" },
+    },
+  },
+}
+```
+
+A complete example config (with identity and channels) is in [`openclaw.json`](openclaw.json) alongside this README.
+
+**3. Start the gateway:**
+
+```bash
+openclaw gateway start
+```
+
+**4. Verify:**
+
+```bash
+openclaw gateway health
+openclaw models list
+```
+
+You should see your Neuralwatt model in the list.
+
+## Channels
+
+OpenClaw supports 20+ messaging channels. The most common ones:
+
+| Channel | Setup |
+|---------|-------|
+| Web UI | Built-in at `http://localhost:18789` |
+| Telegram | Add `channels.telegram.token` in config |
+| Discord | Add `channels.discord.token` in config |
+| WhatsApp | Add `channels.whatsapp.allowFrom` and scan QR |
+
+See the [OpenClaw channel docs](https://github.com/openclaw/openclaw/tree/main/docs/channels) for full setup instructions per channel.
+
+## Available Models
+
+Check [portal.neuralwatt.com](https://portal.neuralwatt.com) or query the API:
+
+```bash
+curl -s -H "Authorization: Bearer $NEURALWATT_API_KEY" \
+  https://api.neuralwatt.com/v1/models | jq '.data[].id'
+```
+
+To add more models, append them to the `models` array in your provider config.
+
+## Energy Usage
+
+Neuralwatt returns energy consumption data with every API response. You can check your daily usage with the [`nw-usage`](../../scripts/) script:
+
+```bash
+nw-usage
+```
+
+```
+Neuralwatt Usage for 2026-03-26
+  Requests: 42
+  Energy: 156Wh (561600J)
+```
+
+### Energy-aware OpenClaw skill (future)
+
+OpenClaw supports custom skills (markdown files that teach the agent specific behaviors). A Neuralwatt energy skill could teach the assistant to fetch and display per-session energy data, similar to how [EcoClaw](https://github.com/thmtz/ecoclaw) appended energy receipts to every response. This is a natural next step beyond the basic provider integration.

--- a/recipes/openclaw/README.md
+++ b/recipes/openclaw/README.md
@@ -1,6 +1,6 @@
 # OpenClaw with Neuralwatt
 
-[OpenClaw](https://github.com/openclaw/openclaw) is a personal AI assistant gateway that connects to messaging platforms (Telegram, Discord, WhatsApp, Slack, and more) and runs your choice of model behind it. Since Neuralwatt exposes an OpenAI-compatible API, OpenClaw can use it as a provider with a few lines of config.
+[OpenClaw](https://github.com/openclaw/openclaw) is a personal AI assistant gateway that connects to messaging platforms (Telegram, Discord, WhatsApp, Slack, and more) and runs your choice of model behind it. Since Neuralwatt exposes an OpenAI-compatible API, OpenClaw can use it as a provider with zero code changes.
 
 ## Prerequisites
 
@@ -10,88 +10,40 @@
 ## Install
 
 ```bash
-curl -fsSL https://openclaw.ai/install.sh | bash
+npm install -g openclaw@latest
 ```
 
-Or via npm:
+Or via the install script:
 
 ```bash
-npm install -g openclaw@latest
+curl -fsSL https://openclaw.ai/install.sh | bash
 ```
 
 ## Setup
 
-### Option A: Interactive onboarding
-
-The fastest path. OpenClaw's onboard wizard handles provider setup, API key, and channel configuration in one go:
-
-```bash
-openclaw onboard --install-daemon \
-  --auth-choice custom-api-key \
-  --custom-base-url "https://api.neuralwatt.com/v1" \
-  --custom-model-id "Qwen/Qwen3.5-397B-A17B-FP8" \
-  --custom-compatibility openai \
-  --custom-api-key "$NEURALWATT_API_KEY"
-```
-
-When prompted, paste your Neuralwatt API key (or pass it via `--custom-api-key` as shown above).
-
-> **Note:** The onboard wizard uses conservative defaults (16k context, 4k max output). For the full 128k context window our API supports, use Option B or manually edit `~/.openclaw/openclaw.json` after onboarding to set `contextWindow: 131072` and `maxTokens: 32768`.
-
-### Option B: Manual config
-
-**1. Export your API key** (add to `~/.zshrc`):
+**1. Export your API key** (add to `~/.zshrc` or equivalent):
 
 ```bash
 export NEURALWATT_API_KEY="your-api-key-here"
 ```
 
-**2. Register the API key with OpenClaw** so the gateway service can access it:
+**2. Copy the example config:**
+
+```bash
+mkdir -p ~/.openclaw
+cp openclaw.json ~/.openclaw/openclaw.json
+```
+
+The example [`openclaw.json`](openclaw.json) alongside this README has everything pre-configured: gateway mode, provider, model with correct context window (128k) and output limits (32k).
+
+**3. Register your API key with OpenClaw:**
 
 ```bash
 openclaw config set models.providers.neuralwatt.apiKey \
   --ref-provider default --ref-source env --ref-id NEURALWATT_API_KEY
 ```
 
-> **Why not just put the key in the JSON?** OpenClaw resolves secrets through a ref system, not bare strings. A bare `"apiKey": "NEURALWATT_API_KEY"` is sent literally and will return 401. The ref approach also makes the key available to the systemd gateway service, which doesn't inherit your shell environment.
-
-**3. Edit** `~/.openclaw/openclaw.json` (JSON5, comments allowed):
-
-```json5
-{
-  gateway: {
-    mode: "local",
-  },
-  models: {
-    mode: "merge",
-    providers: {
-      neuralwatt: {
-        baseUrl: "https://api.neuralwatt.com/v1",
-        // apiKey is set via `openclaw config set` (step 2)
-        api: "openai-completions",
-        models: [
-          {
-            id: "Qwen/Qwen3.5-397B-A17B-FP8",
-            name: "Qwen3.5 397B",
-            reasoning: false,
-            input: ["text"],
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            contextWindow: 131072,
-            maxTokens: 32768,
-          },
-        ],
-      },
-    },
-  },
-  agents: {
-    defaults: {
-      model: { primary: "neuralwatt/Qwen/Qwen3.5-397B-A17B-FP8" },
-    },
-  },
-}
-```
-
-A complete example config (with identity and channels) is in [`openclaw.json`](openclaw.json) alongside this README.
+OpenClaw resolves secrets through a ref system rather than reading bare strings from the config. This command wires up the env var so both the CLI and the systemd gateway service can access it.
 
 **4. Start the gateway:**
 
@@ -106,7 +58,22 @@ openclaw gateway health
 openclaw models list
 ```
 
-You should see your Neuralwatt model in the list.
+You should see `neuralwatt/Qwen/Qwen3.5-397B-A17B-FP8` in the list. The WebChat UI is at `http://localhost:18789`.
+
+### Alternative: interactive onboarding
+
+If you prefer a wizard, `openclaw onboard` can set up the provider in one command:
+
+```bash
+openclaw onboard --install-daemon \
+  --auth-choice custom-api-key \
+  --custom-base-url "https://api.neuralwatt.com/v1" \
+  --custom-model-id "Qwen/Qwen3.5-397B-A17B-FP8" \
+  --custom-compatibility openai \
+  --custom-api-key "$NEURALWATT_API_KEY"
+```
+
+The wizard uses conservative defaults (16k context, 4k max output). After onboarding, edit `~/.openclaw/openclaw.json` to set `contextWindow: 131072` and `maxTokens: 32768` for the full limits.
 
 ## Channels
 
@@ -114,7 +81,7 @@ OpenClaw supports 20+ messaging channels. The most common ones:
 
 | Channel | Setup | Docs |
 |-|-|-|
-| Web UI | Built-in at `http://localhost:18789` | — |
+| Web UI | Built-in at `http://localhost:18789` | |
 | Telegram | Add `channels.telegram.token` in config | [telegram.md](https://github.com/openclaw/openclaw/blob/main/docs/channels/telegram.md) |
 | Discord | Add `channels.discord.token` in config | [discord.md](https://github.com/openclaw/openclaw/blob/main/docs/channels/discord.md) |
 | WhatsApp | Add `channels.whatsapp.allowFrom` and scan QR | [whatsapp.md](https://github.com/openclaw/openclaw/blob/main/docs/channels/whatsapp.md) |
@@ -141,13 +108,3 @@ Neuralwatt returns energy consumption data with every API response. You can chec
 ```bash
 nw-usage
 ```
-
-```
-Neuralwatt Usage for 2026-03-26
-  Requests: 42
-  Energy: 156Wh (561600J)
-```
-
-### Energy-aware OpenClaw skill (future)
-
-OpenClaw supports custom skills (markdown files that teach the agent specific behaviors). A Neuralwatt energy skill could teach the assistant to fetch and display per-session energy data, similar to how [EcoClaw](https://github.com/thmtz/ecoclaw) appended energy receipts to every response. This is a natural next step beyond the basic provider integration.

--- a/recipes/openclaw/openclaw.json
+++ b/recipes/openclaw/openclaw.json
@@ -1,13 +1,13 @@
 // OpenClaw config for Neuralwatt inference
 // Copy to ~/.openclaw/openclaw.json and adjust to taste.
 // JSON5 format: comments and trailing commas are allowed.
+//
+// IMPORTANT: Set your API key with the CLI before starting the gateway:
+//   openclaw config set models.providers.neuralwatt.apiKey \
+//     --ref-provider default --ref-source env --ref-id NEURALWATT_API_KEY
 {
-  // Set NEURALWATT_API_KEY in your environment or inline it here:
-  // env: { NEURALWATT_API_KEY: "your-api-key-here" },
-
-  identity: {
-    name: "Assistant",
-    theme: "helpful assistant",
+  gateway: {
+    mode: "local",
   },
 
   models: {
@@ -15,7 +15,7 @@
     providers: {
       neuralwatt: {
         baseUrl: "https://api.neuralwatt.com/v1",
-        apiKey: "NEURALWATT_API_KEY",
+        // apiKey is set via `openclaw config set` (see above)
         api: "openai-completions",
         models: [
           {
@@ -36,6 +36,15 @@
     defaults: {
       model: { primary: "neuralwatt/Qwen/Qwen3.5-397B-A17B-FP8" },
     },
+    list: [
+      {
+        id: "main",
+        identity: {
+          name: "Assistant",
+          theme: "helpful assistant",
+        },
+      },
+    ],
   },
 
   // Uncomment and configure the channels you want:

--- a/recipes/openclaw/openclaw.json
+++ b/recipes/openclaw/openclaw.json
@@ -11,7 +11,7 @@
   },
 
   models: {
-    mode: "merge",
+    mode: "replace",
     providers: {
       neuralwatt: {
         baseUrl: "https://api.neuralwatt.com/v1",

--- a/recipes/openclaw/openclaw.json
+++ b/recipes/openclaw/openclaw.json
@@ -1,0 +1,54 @@
+// OpenClaw config for Neuralwatt inference
+// Copy to ~/.openclaw/openclaw.json and adjust to taste.
+// JSON5 format: comments and trailing commas are allowed.
+{
+  // Set NEURALWATT_API_KEY in your environment or inline it here:
+  // env: { NEURALWATT_API_KEY: "your-api-key-here" },
+
+  identity: {
+    name: "Assistant",
+    theme: "helpful assistant",
+  },
+
+  models: {
+    mode: "merge",
+    providers: {
+      neuralwatt: {
+        baseUrl: "https://api.neuralwatt.com/v1",
+        apiKey: "NEURALWATT_API_KEY",
+        api: "openai-completions",
+        models: [
+          {
+            id: "Qwen/Qwen3.5-397B-A17B-FP8",
+            name: "Qwen3.5 397B",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 131072,
+            maxTokens: 32768,
+          },
+        ],
+      },
+    },
+  },
+
+  agents: {
+    defaults: {
+      model: { primary: "neuralwatt/Qwen/Qwen3.5-397B-A17B-FP8" },
+    },
+  },
+
+  // Uncomment and configure the channels you want:
+
+  // channels: {
+  //   telegram: {
+  //     token: "TELEGRAM_BOT_TOKEN",
+  //   },
+  //   discord: {
+  //     token: "DISCORD_BOT_TOKEN",
+  //   },
+  //   whatsapp: {
+  //     allowFrom: ["+15555550123"],
+  //   },
+  // },
+}

--- a/recipes/openclaw/openclaw.json
+++ b/recipes/openclaw/openclaw.json
@@ -11,7 +11,7 @@
   },
 
   models: {
-    mode: "replace",
+    mode: "merge",
     providers: {
       neuralwatt: {
         baseUrl: "https://api.neuralwatt.com/v1",


### PR DESCRIPTION
## Summary

Recipe for using [OpenClaw](https://github.com/openclaw/openclaw) with Neuralwatt as the inference backend. OpenClaw is a personal AI assistant gateway supporting 20+ messaging channels (Telegram, Discord, WhatsApp, Slack, web UI, etc.) with native support for OpenAI-compatible providers.

Since the Neuralwatt API is OpenAI-compatible, the integration is pure config. The recipe includes:
- Step-by-step README (install, config, verify)
- Example `openclaw.json` ready to copy into `~/.openclaw/`
- Top-level README updated with OpenClaw in the integrations table

### Validated end-to-end against OpenClaw 2026.3.24

| Check | Result |
|-|-|
| Install (`npm install -g openclaw@latest`) | Pass |
| Config loads without validation errors | Pass |
| Gateway starts and reports healthy | Pass |
| Model appears in `openclaw models list` | Pass |
| Inference via gateway (`openclaw agent`) | Pass |
| Streaming (SSE chunks including reasoning field) | Pass |
| Prompt caching (cacheRead tokens observed) | Pass |
| WebChat dashboard at localhost:18789 | Pass |
| `openclaw onboard` one-liner | Pass (conservative defaults noted) |

### Issues found and fixed during validation

- Bare `apiKey: "NEURALWATT_API_KEY"` sent literally (401). OpenClaw uses a ref system for secrets. Fixed with `openclaw config set --ref-source env`.
- Missing `gateway.mode: "local"`. Gateway refused to start without it.
- Top-level `identity` key deprecated in 2026.3.24. Moved to `agents.list[].identity`.
- README rewritten: single setup path, correct step ordering, config file as single source of truth.

## Test plan

- [x] Install OpenClaw, apply config, verify model listing
- [x] Send message through gateway, confirm Neuralwatt inference
- [x] Test streaming responses
- [x] Verify `openclaw onboard` one-liner
- [ ] Test external channel (Telegram/Discord) — needs bot token, deferred