### PR TITLE
Add NanoClaw recipe for Neuralwatt inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Get your API key from [portal.neuralwatt.com](https://portal.neuralwatt.com), th
 |-------------|--------------|-------------|
 | [nw-usage](scripts/) | CLI for checking energy usage | `nw-usage` or `nw-usage --tmux` |
 | [Claude Code](recipes/claude-code/) | Anthropic's coding CLI with Neuralwatt models | [Setup guide](recipes/claude-code/README.md) |
+| [NanoClaw](recipes/nanoclaw/) | Lightweight AI assistant (Telegram, Discord, WhatsApp, etc.) | [Setup guide](recipes/nanoclaw/README.md) |
 | [OpenCode](recipes/opencode/) | AI coding agent CLI | [Setup guide](recipes/opencode/README.md) |
 | [llm plugin](plugins/llm-neuralwatt/) | Use Neuralwatt with [simonw/llm](https://llm.datasette.io/) CLI | [Setup guide](plugins/llm-neuralwatt/README.md) |
 | [Neovim](recipes/neovim/) | AI completions + energy monitor | [Setup guide](recipes/neovim/README.md) |
@@ -57,6 +58,7 @@ neuralwatt-tools/
 │   └── llm-neuralwatt/      # pip-installable LLM plugin
 └── recipes/
     ├── claude-code/         # Anthropic's coding CLI setup
+    ├── nanoclaw/            # Lightweight AI assistant gateway
     ├── opencode/            # AI coding agent CLI setup
     ├── neovim/              # Energy monitor + AI plugin configs
     └── tmux/                # Statusline integration

--- a/recipes/nanoclaw/README.md
+++ b/recipes/nanoclaw/README.md
@@ -1,0 +1,125 @@
+# NanoClaw with Neuralwatt
+
+[NanoClaw](https://github.com/qwibitai/nanoclaw) is a lightweight AI assistant that runs in containers, connecting to WhatsApp, Telegram, Discord, and other messaging channels. It's built on the Anthropic Agent SDK, which normally talks to Claude. Using a translation proxy, you can point it at Neuralwatt instead.
+
+> **Note:** Using NanoClaw with non-Anthropic models is not officially supported by NanoClaw or Anthropic.
+
+## How It Works
+
+NanoClaw agents speak the Anthropic Messages API. Neuralwatt exposes an OpenAI-compatible Chat Completions API. A translation proxy converts between the two formats:
+
+```
+NanoClaw container → Anthropic Messages API
+  → Translation proxy (localhost:3000)
+    → OpenAI Chat Completions → api.neuralwatt.com/v1
+```
+
+## Prerequisites
+
+- [Neuralwatt API key](https://portal.neuralwatt.com)
+- A working [NanoClaw](https://github.com/qwibitai/nanoclaw) installation
+- Node.js 18+ and Git
+
+## Setup
+
+**1. Export your API key** (add to `~/.zshrc`):
+
+```bash
+export NEURALWATT_API_KEY="your-api-key-here"
+```
+
+**2. Install the translation proxy:**
+
+We use [anthropic-proxy](https://github.com/maxnowack/anthropic-proxy), a small Node.js server that translates Anthropic requests to OpenAI format. The stock version skips auth headers for custom endpoints, so we apply a one-line patch:
+
+```bash
+git clone https://github.com/maxnowack/anthropic-proxy.git ~/neuralwatt-proxy
+cd ~/neuralwatt-proxy
+npm install
+sed -i 's/const requiresApiKey = !process.env.ANTHROPIC_PROXY_BASE_URL/const requiresApiKey = true/' index.js
+```
+
+**3. Start the proxy:**
+
+```bash
+cd ~/neuralwatt-proxy
+ANTHROPIC_PROXY_BASE_URL=https://api.neuralwatt.com \
+OPENROUTER_API_KEY=$NEURALWATT_API_KEY \
+COMPLETION_MODEL=Qwen/Qwen3.5-397B-A17B-FP8 \
+REASONING_MODEL=Qwen/Qwen3.5-397B-A17B-FP8 \
+node index.js
+```
+
+The proxy listens on port 3000 by default. Set `PORT=<number>` to change it.
+
+**4. Switch NanoClaw to the native credential proxy:**
+
+NanoClaw's default credential mechanism (OneCLI) manages API keys outside the container and routes traffic through its own gateway. To use Neuralwatt instead, switch to the native credential proxy, which reads `ANTHROPIC_BASE_URL` from `.env`:
+
+```bash
+cd /path/to/nanoclaw
+claude /use-native-credential-proxy
+```
+
+Then set the following in your NanoClaw `.env`:
+
+```bash
+ANTHROPIC_BASE_URL=http://host.docker.internal:3000
+ANTHROPIC_API_KEY=not-used-but-required
+```
+
+`host.docker.internal` lets containers reach the proxy running on the host. NanoClaw handles the `--add-host` flag automatically on Linux.
+
+**5. Restart NanoClaw:**
+
+```bash
+npm run dev
+```
+
+Send a test message through any connected channel. The agent should respond using the Neuralwatt model.
+
+## Verify
+
+Test the proxy directly:
+
+```bash
+curl -s http://localhost:3000/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: anything" \
+  -d '{
+    "model": "claude-3-5-sonnet-20241022",
+    "max_tokens": 100,
+    "messages": [{"role": "user", "content": "Say hello and tell me what model you are."}]
+  }' | jq .
+```
+
+The response should come from Qwen, not Claude. The proxy logs will show requests being translated and forwarded.
+
+## Available Models
+
+Check [portal.neuralwatt.com](https://portal.neuralwatt.com) or query the API:
+
+```bash
+curl -s -H "Authorization: Bearer $NEURALWATT_API_KEY" \
+  https://api.neuralwatt.com/v1/models | jq '.data[].id'
+```
+
+To switch models, change `COMPLETION_MODEL` and `REASONING_MODEL` when starting the proxy.
+
+## Limitations
+
+The proxy translates tool schemas between Anthropic and OpenAI formats. Complex tool definitions may hit edge cases, so test your specific workflows. NanoClaw sends Claude model names but the proxy ignores them, routing everything to `COMPLETION_MODEL`. The proxy normalizes multi-part content to plain text, so image inputs may not survive the translation.
+
+## Energy Usage
+
+Neuralwatt returns energy data with every response. Check your usage with the [`nw-usage`](../../scripts/) script:
+
+```bash
+nw-usage
+```
+
+```
+Neuralwatt Usage for 2026-03-27
+  Requests: 42
+  Energy: 156Wh (561600J)
+```

--- a/recipes/nanoclaw/TEST-INSTRUCTIONS.md
+++ b/recipes/nanoclaw/TEST-INSTRUCTIONS.md
@@ -1,0 +1,161 @@
+# Testing the NanoClaw + Neuralwatt Recipe
+
+Self-contained test plan for validating the translation proxy that lets NanoClaw talk to Neuralwatt. No prior context needed.
+
+## Background
+
+NanoClaw is an AI assistant built on the Anthropic Agent SDK (speaks Anthropic Messages API). Neuralwatt serves open-source models like Qwen via an OpenAI-compatible API at `api.neuralwatt.com/v1`. A translation proxy bridges the two formats.
+
+You don't need a full NanoClaw installation. The core question is whether the proxy correctly translates Anthropic-format requests to OpenAI format, forwards them to Neuralwatt, and translates responses back.
+
+## Prerequisites
+
+- Node.js 18+ and Git
+- A Neuralwatt API key set as `NEURALWATT_API_KEY`. Get a free key at https://portal.neuralwatt.com if needed.
+
+## Tests
+
+**1. Verify Neuralwatt API access:**
+
+```bash
+curl -s -H "Authorization: Bearer $NEURALWATT_API_KEY" \
+  https://api.neuralwatt.com/v1/models | jq '.data[].id'
+```
+
+You should see model IDs like `Qwen/Qwen3.5-397B-A17B-FP8`.
+
+**2. Set up the translation proxy:**
+
+```bash
+cd /tmp
+git clone https://github.com/maxnowack/anthropic-proxy.git neuralwatt-proxy
+cd neuralwatt-proxy
+npm install
+
+# The stock proxy skips auth headers for custom URLs. Patch it:
+sed -i 's/const requiresApiKey = !process.env.ANTHROPIC_PROXY_BASE_URL/const requiresApiKey = true/' index.js
+
+# Verify:
+grep 'const requiresApiKey' index.js
+# Should show: const requiresApiKey = true
+```
+
+**3. Start the proxy:**
+
+```bash
+ANTHROPIC_PROXY_BASE_URL=https://api.neuralwatt.com \
+OPENROUTER_API_KEY=$NEURALWATT_API_KEY \
+COMPLETION_MODEL=Qwen/Qwen3.5-397B-A17B-FP8 \
+REASONING_MODEL=Qwen/Qwen3.5-397B-A17B-FP8 \
+PORT=3000 \
+node index.js &
+
+sleep 2
+```
+
+**4. Basic request (non-streaming):**
+
+```bash
+curl -s http://localhost:3000/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: placeholder" \
+  -d '{
+    "model": "claude-3-5-sonnet-20241022",
+    "max_tokens": 150,
+    "stream": false,
+    "messages": [
+      {"role": "user", "content": "Say hello and identify what model you are. Be brief."}
+    ]
+  }' | jq .
+```
+
+Expected: JSON in Anthropic Messages format with `type: "message"`, a `content` array containing a `text` block, `usage` with token counts. The model should identify as Qwen, not Claude.
+
+**5. Streaming request:**
+
+```bash
+curl -s http://localhost:3000/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: placeholder" \
+  -d '{
+    "model": "claude-3-5-sonnet-20241022",
+    "max_tokens": 150,
+    "stream": true,
+    "messages": [
+      {"role": "user", "content": "Count from 1 to 5."}
+    ]
+  }'
+```
+
+Expected: SSE stream with `message_start`, `content_block_start`, multiple `content_block_delta` events with `text_delta`, then `content_block_stop`, `message_delta` (with `stop_reason: "end_turn"`), and `message_stop`.
+
+**6. Tool calls:**
+
+```bash
+curl -s http://localhost:3000/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: placeholder" \
+  -d '{
+    "model": "claude-3-5-sonnet-20241022",
+    "max_tokens": 300,
+    "stream": false,
+    "messages": [
+      {"role": "user", "content": "What is the weather in San Francisco?"}
+    ],
+    "tools": [
+      {
+        "name": "get_weather",
+        "description": "Get the current weather in a given location",
+        "input_schema": {
+          "type": "object",
+          "properties": {
+            "location": {"type": "string", "description": "City and state"}
+          },
+          "required": ["location"]
+        }
+      }
+    ]
+  }' | jq .
+```
+
+Expected: Response contains a `tool_use` content block with `name: "get_weather"` and an `input` object like `{"location": "San Francisco, CA"}`.
+
+**7. System messages:**
+
+```bash
+curl -s http://localhost:3000/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: placeholder" \
+  -d '{
+    "model": "claude-3-5-sonnet-20241022",
+    "max_tokens": 100,
+    "stream": false,
+    "system": [{"type": "text", "text": "You are a pirate. Respond in pirate speak only."}],
+    "messages": [
+      {"role": "user", "content": "How are you today?"}
+    ]
+  }' | jq .
+```
+
+Expected: Response in pirate speak, confirming system messages reach the model.
+
+**8. Cleanup:**
+
+```bash
+kill %1 2>/dev/null
+rm -rf /tmp/neuralwatt-proxy
+```
+
+## What to Report
+
+For each test: pass or fail, with actual output for failures. Note whether the `sed` patch applied cleanly and whether the model identified as Qwen (not Claude).
+
+Also read the recipe README at `recipes/nanoclaw/README.md` and flag anything wrong, unclear, or missing.
+
+## Troubleshooting
+
+Connection refused on port 3000 means the proxy failed to start. Check its stderr.
+
+401/403 from Neuralwatt means the API key isn't being forwarded. Verify the `sed` patch applied and that `NEURALWATT_API_KEY` is set.
+
+Unparseable JSON in tool call `input` fields usually means the model's tool calling isn't as reliable as Claude's. That's a model limitation, not a proxy bug.


### PR DESCRIPTION
## Summary

Add a recipe showing how to run [NanoClaw](https://github.com/qwibitai/nanoclaw) agents on Neuralwatt models instead of Claude.

NanoClaw is built on Anthropic's Agent SDK, so it speaks the Anthropic Messages API. Neuralwatt exposes an OpenAI-compatible Chat Completions API. The recipe uses [anthropic-proxy](https://github.com/maxnowack/anthropic-proxy) as a translation layer between the two formats. A one-line `sed` patch fixes the proxy's auth handling for custom endpoints.

The recipe covers:
- Installing and patching anthropic-proxy to forward auth headers to Neuralwatt
- Switching NanoClaw from OneCLI (default credential mechanism) to the native credential proxy via `/use-native-credential-proxy`, which enables `ANTHROPIC_BASE_URL` support
- Configuring `.env` to point at the local proxy
- Verification with curl

Also includes `TEST-INSTRUCTIONS.md` with a self-contained test plan (curl commands for basic chat, streaming, tool calls, and system messages). This can be run without a full NanoClaw installation to validate the proxy layer independently.

**NOT YET TESTED.** The proxy chain needs end-to-end validation. Specific things to verify:

1. Clone anthropic-proxy, apply the `sed` patch, `npm install`
2. Start the proxy with `ANTHROPIC_PROXY_BASE_URL=https://api.neuralwatt.com` and `OPENROUTER_API_KEY=$NEURALWATT_API_KEY`
3. Send a non-streaming Anthropic Messages API request to `localhost:3000/v1/messages` and confirm a valid response comes back from Qwen (not Claude)
4. Test streaming (SSE events should have correct Anthropic event types: `message_start`, `content_block_delta`, etc.)
5. Test tool calls (Anthropic `tool_use` format in response)
6. Test system messages (should be forwarded to the model)
7. Optionally: set up NanoClaw with `/use-native-credential-proxy` and `ANTHROPIC_BASE_URL=http://host.docker.internal:3000`, send a real message through a channel, confirm the agent responds via Neuralwatt

The full test plan is in `recipes/nanoclaw/TEST-INSTRUCTIONS.md`.

## Test plan

- [ ] Proxy setup: clone, patch, npm install, start
- [ ] Non-streaming request returns valid Anthropic Messages response from Qwen
- [ ] Streaming request returns correct SSE event sequence
- [ ] Tool calls translate between Anthropic and OpenAI formats
- [ ] System messages forwarded correctly
- [ ] (Optional) Full NanoClaw end-to-end with a messaging channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)