### PR TITLE
Fix shellcheck warnings and harden install-nw-usage

### DIFF
--- a/scripts/install-nw-usage
+++ b/scripts/install-nw-usage
@@ -20,7 +20,8 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-# Command template for Opencode
+# Command template for Opencode (backticks are literal, not expansions)
+# shellcheck disable=SC2016
 COMMAND_JSON='{
   "command": {
     "nw-usage": {
@@ -30,7 +31,8 @@ COMMAND_JSON='{
   }
 }'
 
-# Markdown command for project install
+# Markdown command for project install (backticks are literal, not expansions)
+# shellcheck disable=SC2016
 COMMAND_MD='---
 description: Show Neuralwatt energy usage
 ---
@@ -81,16 +83,25 @@ check_dependencies() {
 }
 
 install_script() {
+    # Verify source script exists
+    if [[ ! -x "$NW_USAGE_SCRIPT" ]]; then
+        log_error "nw-usage script not found at $NW_USAGE_SCRIPT"
+        exit 1
+    fi
+
     # Ensure ~/.local/bin exists
     mkdir -p "$INSTALL_DIR"
-    
+
     # Create symlink (remove existing if present)
     local symlink="$INSTALL_DIR/nw-usage"
-    if [[ -L "$symlink" ]] || [[ -e "$symlink" ]]; then
+    if [[ -L "$symlink" ]]; then
         rm "$symlink"
-        log_info "Removed existing nw-usage"
+        log_info "Removed existing nw-usage symlink"
+    elif [[ -e "$symlink" ]]; then
+        log_error "$symlink already exists and is not a symlink. Remove it manually."
+        exit 1
     fi
-    
+
     ln -s "$NW_USAGE_SCRIPT" "$symlink"
     log_info "Created symlink: $symlink -> $NW_USAGE_SCRIPT"
     
@@ -100,12 +111,12 @@ install_script() {
 
 check_path() {
     if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
-        log_warn "~/.local/bin is not in your PATH"
+        log_warn "$HOME/.local/bin is not in your PATH"
         echo "  Add to your shell config (~/.zshrc, ~/.bashrc, etc.):"
         echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
         echo "  Then reload: source ~/.zshrc"
     else
-        log_info "~/.local/bin is in PATH"
+        log_info "$HOME/.local/bin is in PATH"
     fi
 }
 
@@ -121,7 +132,7 @@ install_global_command() {
         local temp_file
         temp_file="$(mktemp)"
         
-        if jq -s '.[0] * .[1]' "$OPENCODE_GLOBAL_CONFIG" <(echo "$COMMAND_JSON") > "$temp_file"; then
+        if jq -s '.[0] * {command: ((.[0].command // {}) * (.[1].command // {}))}' "$OPENCODE_GLOBAL_CONFIG" <(echo "$COMMAND_JSON") > "$temp_file"; then
             mv "$temp_file" "$OPENCODE_GLOBAL_CONFIG"
             log_info "Added nw-usage command to $OPENCODE_GLOBAL_CONFIG"
         else
@@ -177,7 +188,7 @@ main() {
     if [[ -z "$mode" ]]; then
         echo "Where should the Opencode command be installed?"
         echo ""
-        read -p "Global (default) or project? [Y/n]: " choice
+        read -rp "Global (default) or project? [Y/n]: " choice
         case "$choice" in
             n|N|no|No|NO) mode="project" ;;
             *) mode="global" ;;


### PR DESCRIPTION
## Summary

Follow-up fixes for #10:

- **Fix all shellcheck warnings** (SC2016, SC2088, SC2162) that cause CI failure
- **Fix JSON merge** to preserve existing commands in opencode.json (deep merge on `.command` key instead of shallow top-level merge)
- **Validate source script exists** before creating symlink (prevents dangling symlinks)
- **Refuse to overwrite non-symlink files** at the install target (safety check)

## Test plan

- [ ] `shellcheck scripts/install-nw-usage` passes clean
- [ ] CI passes
- [ ] Global install preserves existing commands in opencode.json
- [ ] Installer errors when nw-usage source script is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)