### PR TITLE
chore: add pre-push hook to block direct pushes to main and add CLAUDE.md

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,23 @@
+#!/bin/bash
+# pre-push hook: block direct pushes to main.
+# Override with: ALLOW_MAIN=1 git push
+#
+# Enable: git config core.hooksPath .githooks
+
+protected_branches="main"
+current_branch=$(git symbolic-ref --short HEAD 2>/dev/null)
+
+for branch in $protected_branches; do
+    if [ "$current_branch" = "$branch" ]; then
+        if [ "$ALLOW_MAIN" = "1" ]; then
+            echo "⚠️  ALLOW_MAIN=1 set — bypassing push protection for $branch"
+            exit 0
+        fi
+        echo "🚫 Direct push to '$branch' is blocked."
+        echo "   Use a feature branch and open a PR instead."
+        echo ""
+        echo "   To override in an emergency:"
+        echo "     ALLOW_MAIN=1 git push"
+        exit 1
+    fi
+done

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -4,16 +4,13 @@
 #
 # Enable: git config core.hooksPath .githooks
 
-protected_branches="main"
-current_branch=$(git symbolic-ref --short HEAD 2>/dev/null)
-
-for branch in $protected_branches; do
-    if [ "$current_branch" = "$branch" ]; then
+while read -r local_ref local_sha remote_ref remote_sha; do
+    if [ "$remote_ref" = "refs/heads/main" ]; then
         if [ "$ALLOW_MAIN" = "1" ]; then
-            echo "⚠️  ALLOW_MAIN=1 set — bypassing push protection for $branch"
+            echo "⚠️  ALLOW_MAIN=1 set — bypassing push protection for main"
             exit 0
         fi
-        echo "🚫 Direct push to '$branch' is blocked."
+        echo "🚫 Direct push to 'main' is blocked."
         echo "   Use a feature branch and open a PR instead."
         echo ""
         echo "   To override in an emergency:"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# Neuralwatt Tools
+
+Neuralwatt tools, plugins, and recipes for AI inference workflows.
+
+## Workflow
+
+This repository uses **trunk-based development**:
+
+1. **Create feature branches** from `main` for all changes
+2. **Push changes as Pull Requests** targeting `main`
+3. **Never push directly to `main`**
+
+### Git Hooks
+
+Enable on every fresh clone:
+```bash
+git config core.hooksPath .githooks
+```
+This is a per-clone setting and must be re-run after cloning to a new machine.
+
+**Pre-push hook** — blocks direct pushes to `main`. All changes should go
+through a feature branch + PR.
+
+To override in an emergency: `ALLOW_MAIN=1 git push`


### PR DESCRIPTION
## Summary
- Adds `.githooks/pre-push` script that blocks direct pushes to `main`
- Updates CLAUDE.md with Git Hooks section documenting the hook

## Why a git hook instead of GitHub branch protection?

Branch protection is repo-wide — it blocks everyone, and must be temporarily disabled in Settings for hotfixes. Since our agents use our personal GitHub accounts, there is no way to block agents without also blocking ourselves.

This git hook is opt-in: you enable it per-clone with `git config core.hooksPath .githooks`. Its purpose is to catch *accidental* pushes to main — not to enforce a hard policy. You can still push directly to main if needed (e.g. hotfixes) by running `ALLOW_MAIN=1 git push`.

## Setup

After cloning (one-time):
```bash
git config core.hooksPath .githooks
```

## Test plan
- [x] `git push` on main → blocked with clear error and override instructions
- [x] `ALLOW_MAIN=1 git push` → bypasses with a warning
- [x] `git push` on feature branches → unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)