### PR TITLE
Add Hermes Agent recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Get your API key from [portal.neuralwatt.com](https://portal.neuralwatt.com), th
 | [nw-usage](scripts/) | CLI for checking energy usage | `nw-usage` or `nw-usage --tmux` |
 | [Claude Code](recipes/claude-code/) | Anthropic's coding CLI with Neuralwatt models | [Setup guide](recipes/claude-code/README.md) |
 | [OpenClaw](recipes/openclaw/) | Personal AI assistant gateway (Telegram, Discord, WhatsApp, etc.) | [Setup guide](recipes/openclaw/README.md) |
+| [Hermes Agent](recipes/hermes/) | Self-improving AI agent from Nous Research with messaging gateway | [Setup guide](recipes/hermes/README.md) |
 | [OpenCode](recipes/opencode/) | AI coding agent CLI | [Setup guide](recipes/opencode/README.md) |
 | [llm plugin](plugins/llm-neuralwatt/) | Use Neuralwatt with [simonw/llm](https://llm.datasette.io/) CLI | [Setup guide](plugins/llm-neuralwatt/README.md) |
 | [Neovim](recipes/neovim/) | AI completions + energy monitor | [Setup guide](recipes/neovim/README.md) |
@@ -59,6 +60,7 @@ neuralwatt-tools/
 └── recipes/
     ├── claude-code/         # Anthropic's coding CLI setup
     ├── openclaw/            # Personal AI assistant gateway
+    ├── hermes/              # Nous Research Hermes Agent setup
     ├── opencode/            # AI coding agent CLI setup
     ├── neovim/              # Energy monitor + AI plugin configs
     └── tmux/                # Statusline integration

--- a/recipes/hermes/README.md
+++ b/recipes/hermes/README.md
@@ -1,6 +1,6 @@
 # Hermes Agent with Neuralwatt
 
-[Hermes Agent](https://github.com/NousResearch/hermes-agent) is a self-improving AI agent from [Nous Research](https://nousresearch.com) that runs locally or on a VPS and can talk to you from Telegram, Discord, Slack, WhatsApp, Signal, or a terminal UI. It supports any OpenAI-compatible endpoint, so Neuralwatt works as a drop-in provider.
+[Hermes Agent](https://github.com/NousResearch/hermes-agent) is a self-improving AI agent from [Nous Research](https://nousresearch.com) that runs locally or on a VPS and can talk to you from Telegram, Discord, Slack, WhatsApp, Signal, or a terminal UI. It accepts any OpenAI-compatible endpoint, so you can point it at the Neuralwatt API as the inference backend.
 
 ## Prerequisites
 

--- a/recipes/hermes/README.md
+++ b/recipes/hermes/README.md
@@ -1,0 +1,73 @@
+# Hermes Agent with Neuralwatt
+
+[Hermes Agent](https://github.com/NousResearch/hermes-agent) is a self-improving AI agent from [Nous Research](https://nousresearch.com) that runs locally or on a VPS and can talk to you from Telegram, Discord, Slack, WhatsApp, Signal, or a terminal UI. It supports any OpenAI-compatible endpoint, so Neuralwatt works as a drop-in provider.
+
+## Prerequisites
+
+- [Neuralwatt API key](https://portal.neuralwatt.com)
+- Linux, macOS, WSL2, or Termux (native Windows is not supported)
+
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+source ~/.zshrc   # or ~/.bashrc
+```
+
+The installer creates `~/.hermes/` with `config.yaml`, `.env`, and the agent source tree.
+
+## Setup
+
+Hermes treats any non-blessed OpenAI-compatible endpoint as a `custom` provider. Two small edits wire Neuralwatt in.
+
+Edit `~/.hermes/config.yaml` and set the `model` block:
+
+```yaml
+model:
+  default: "moonshotai/Kimi-K2.5"
+  provider: "custom"
+  base_url: "https://api.neuralwatt.com/v1"
+```
+
+Then append your key to `~/.hermes/.env`:
+
+```bash
+OPENAI_API_KEY=your-api-key-here
+OPENAI_BASE_URL=https://api.neuralwatt.com/v1
+```
+
+Hermes reads `OPENAI_API_KEY` and `OPENAI_BASE_URL` when the provider is `custom`.
+
+Verify the install:
+
+```bash
+hermes doctor
+```
+
+## Run
+
+```bash
+hermes
+```
+
+You can swap models mid-session with `/model <model-id>`. Hermes won't autocomplete the Neuralwatt catalog, so type the full model ID manually (for example `/model Qwen/Qwen3.5-397B-A17B-FP8`).
+
+## Available Models
+
+Browse the full catalog at [portal.neuralwatt.com](https://portal.neuralwatt.com), or query the API directly:
+
+```bash
+curl -s -H "Authorization: Bearer $NEURALWATT_API_KEY" \
+  https://api.neuralwatt.com/v1/models | jq '.data[].id'
+```
+
+## Messaging Gateway
+
+Hermes can run as a background gateway that bridges Telegram, Discord, Slack, WhatsApp, Signal, and email into a single agent. Configure it with:
+
+```bash
+hermes gateway setup
+hermes gateway start
+```
+
+See the [messaging gateway guide](https://hermes-agent.nousresearch.com/docs/user-guide/messaging) for platform-specific setup.


### PR DESCRIPTION
## Summary
- New recipe at `recipes/hermes/README.md` showing how to install [Hermes Agent](https://github.com/NousResearch/hermes-agent) and point it at the Neuralwatt API as a `custom` OpenAI-compatible provider.
- Adds Hermes to the integrations table and tree in the root `README.md`.

## Test plan
- [x] Followed the recipe end-to-end on devbox — `hermes` launches, chats via `api.neuralwatt.com`, and `hermes doctor` is clean.
- [x] Verified `/model <id>` swaps models mid-session (no autocompletion for the NW catalog, documented).
- [x] Cross-checked every URL and factual claim against upstream Hermes docs and our live install.