### PR TITLE
docs: fix Crush recipe install tap and config path

### DIFF
--- a/recipes/crush/README.md
+++ b/recipes/crush/README.md
@@ -12,14 +12,35 @@
 
 ```bash
 # Homebrew (macOS/Linux)
-brew install charm-sh/tap/crush
+brew install charmbracelet/tap/crush
 
-# Or download from https://github.com/charmbracelet/crush
+# Debian/Ubuntu
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://repo.charm.sh/apt/gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/charm.gpg
+echo "deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *" | sudo tee /etc/apt/sources.list.d/charm.list
+sudo apt update && sudo apt install crush
+
+# Fedora/RHEL
+echo '[charm]
+name=Charm
+baseurl=https://repo.charm.sh/yum/
+enabled=1
+gpgcheck=1
+gpgkey=https://repo.charm.sh/yum/gpg.key' | sudo tee /etc/yum.repos.d/charm.repo
+sudo yum install crush
+
+# Arch Linux
+yay -S crush-bin
+
+# NPM
+npm install -g @charmland/crush
 ```
+
+Binaries, `.deb`, and `.rpm` packages are also available on the [releases page](https://github.com/charmbracelet/crush/releases).
 
 ## Setup
 
-**Export your API key** (add to `~/.zshrc`):
+**Export your API key** (add to your shell config, e.g. `~/.zshrc` or `~/.bashrc`):
 
 ```bash
 export NEURALWATT_API_KEY="your-api-key-here"
@@ -40,7 +61,7 @@ crush
 3. Filter by "Neuralwatt"
 4. Pick a model
 
-You can also set a default model in `~/.local/share/crush/crush.json`:
+You can also set a default model in `~/.config/crush/crush.json`:
 
 ```json
 {


### PR DESCRIPTION
## Summary
- Fix Homebrew tap: `charm-sh/tap` → `charmbracelet/tap` (verified against upstream README).
- Fix default-model config path: `~/.local/share/crush/crush.json` → `~/.config/crush/crush.json` (the former is the data dir, not the config dir).
- Expand install section with Debian/Ubuntu, Fedora/RHEL, Arch, and NPM options pulled from the upstream README, plus a pointer to the releases page for binaries/deb/rpm.
- Broaden shell rc example from `~/.zshrc` to `~/.zshrc` or `~/.bashrc`.

## Test plan
- [x] Verified brew tap against https://github.com/charmbracelet/crush README
- [x] Verified config path against upstream README (global config lives under `$HOME/.config/crush/crush.json`)
- [x] Verified model ID `Qwen/Qwen3.5-397B-A17B-FP8` exists via `api.neuralwatt.com/v1/models`
- [x] Auto-discovery via `NEURALWATT_API_KEY` confirmed working out of the box (Crush fetches providers from Catwalk, which registers Neuralwatt)