### PR TITLE
Add nw-opencode-config: auto-generate OpenCode config from live API

### DIFF
--- a/recipes/opencode/README.md
+++ b/recipes/opencode/README.md
@@ -28,7 +28,7 @@ nw-opencode-config --write
 nw-opencode-config --write --default zai-org/GLM-5.1-FP8
 ```
 
-This fetches all available models from the Neuralwatt API and writes the config to `~/.config/opencode/opencode.json`. It **merges** with your existing config — your other providers and settings are preserved.
+This fetches all available models from the Neuralwatt API and writes the config to `~/.config/opencode/opencode.json`. It **merges** with your existing config — your other providers, your `.model` default, and your `command.nw-usage` wording are preserved. Re-running refreshes the Neuralwatt model list and drops any models no longer in the API. See [scripts/README.md](../../scripts/) for the full merge rules.
 
 ### Manual config
 

--- a/recipes/opencode/README.md
+++ b/recipes/opencode/README.md
@@ -18,21 +18,26 @@ brew install anomalyco/tap/opencode
 export NEURALWATT_API_KEY="your-api-key-here"
 ```
 
-**2. Generate config** using the `nw-opencode-config` script:
+**2. Generate config** using the `nw-opencode-config` script. It prints a full `opencode.json` to stdout — you redirect it yourself:
 
 ```bash
-# Auto-generate config from the live Neuralwatt API
-nw-opencode-config --write
+# Fresh install — redirect straight into place
+nw-opencode-config > ~/.config/opencode/opencode.json
 
-# Or specify a default model
-nw-opencode-config --write --default zai-org/GLM-5.1-FP8
+# Pick a different default model
+nw-opencode-config --default zai-org/GLM-5.1-FP8 > ~/.config/opencode/opencode.json
 ```
 
-This fetches all available models from the Neuralwatt API and writes the config to `~/.config/opencode/opencode.json`. It **merges** with your existing config — your other providers, your `.model` default, and your `command.nw-usage` wording are preserved. Re-running refreshes the Neuralwatt model list and drops any models no longer in the API. See [scripts/README.md](../../scripts/) for the full merge rules.
+The script never writes to your config file. If you already have an `opencode.json` with other providers, don't redirect over it — generate just the models block and merge it in manually:
+
+```bash
+nw-opencode-config --models-only | pbcopy
+# paste under provider.neuralwatt.models in your existing config
+```
 
 ### Manual config
 
-If you prefer to create the config manually, create `~/.config/opencode/opencode.json`:
+If you prefer to write it by hand, create `~/.config/opencode/opencode.json`:
 
 ```json
 {
@@ -66,15 +71,14 @@ opencode
 
 ## nw-opencode-config
 
-The `nw-opencode-config` script generates an OpenCode config from the live Neuralwatt API.
+The `nw-opencode-config` script prints an OpenCode config generated from the live Neuralwatt API. It **never writes to your config file** — you control where the output goes.
 
 ```bash
-nw-opencode-config                        # Print config to stdout
-nw-opencode-config --write                # Write to ~/.config/opencode/opencode.json
-nw-opencode-config --models-only          # Print just the models block
-nw-opencode-config --list                 # List available models
+nw-opencode-config                        # Full config to stdout
+nw-opencode-config --models-only          # Just the models block
+nw-opencode-config --list                 # List available models (human-readable)
 nw-opencode-config --include-aliases      # Include alias/fast models
-nw-opencode-config --default MODEL_ID     # Set default model
+nw-opencode-config --default MODEL_ID     # Override default in output
 nw-opencode-config --help
 ```
 
@@ -82,9 +86,15 @@ nw-opencode-config --help
 
 1. Fetches model IDs and context limits from `https://api.neuralwatt.com/v1/models`
 2. Merges with curated metadata ([`opencode-models.json`](../../scripts/opencode-models.json)) for display names, output limits, and model-specific options (e.g., Kimi K2.5's recommended `repetitionPenalty`)
-3. Outputs a valid `opencode.json` with the Neuralwatt provider and `/nw-usage` command
+3. Prints a valid `opencode.json` with the Neuralwatt provider and `/nw-usage` command
 
-New models appear automatically when added to the API. To update your config, just re-run `nw-opencode-config --write`.
+New models appear automatically when added to the API. To refresh your config, re-run and redirect:
+
+```bash
+nw-opencode-config > ~/.config/opencode/opencode.json
+```
+
+(Only do this if your config has no other providers you care about. Otherwise use `--models-only` and merge by hand.)
 
 ### Installation
 

--- a/recipes/opencode/README.md
+++ b/recipes/opencode/README.md
@@ -18,7 +18,21 @@ brew install anomalyco/tap/opencode
 export NEURALWATT_API_KEY="your-api-key-here"
 ```
 
-**2. Create config** at `~/.config/opencode/opencode.json`:
+**2. Generate config** using the `nw-opencode-config` script:
+
+```bash
+# Auto-generate config from the live Neuralwatt API
+nw-opencode-config --write
+
+# Or specify a default model
+nw-opencode-config --write --default zai-org/GLM-5.1-FP8
+```
+
+This fetches all available models from the Neuralwatt API and writes the config to `~/.config/opencode/opencode.json`. It **merges** with your existing config — your other providers and settings are preserved.
+
+### Manual config
+
+If you prefer to create the config manually, create `~/.config/opencode/opencode.json`:
 
 ```json
 {
@@ -42,15 +56,45 @@ export NEURALWATT_API_KEY="your-api-key-here"
 }
 ```
 
+Use `nw-opencode-config --list` to see all available models with their context limits.
+
 ## Run
 
 ```bash
 opencode
 ```
 
+## nw-opencode-config
+
+The `nw-opencode-config` script generates an OpenCode config from the live Neuralwatt API.
+
+```bash
+nw-opencode-config                        # Print config to stdout
+nw-opencode-config --write                # Write to ~/.config/opencode/opencode.json
+nw-opencode-config --models-only          # Print just the models block
+nw-opencode-config --list                 # List available models
+nw-opencode-config --include-aliases      # Include alias/fast models
+nw-opencode-config --default MODEL_ID     # Set default model
+nw-opencode-config --help
+```
+
+### How it works
+
+1. Fetches model IDs and context limits from `https://api.neuralwatt.com/v1/models`
+2. Merges with curated metadata ([`opencode-models.json`](../../scripts/opencode-models.json)) for display names, output limits, and model-specific options (e.g., Kimi K2.5's recommended `repetitionPenalty`)
+3. Outputs a valid `opencode.json` with the Neuralwatt provider and `/nw-usage` command
+
+New models appear automatically when added to the API. To update your config, just re-run `nw-opencode-config --write`.
+
+### Installation
+
+```bash
+ln -s /path/to/neuralwatt-tools/scripts/nw-opencode-config ~/.local/bin/
+```
+
 ## Energy Usage Command
 
-Add a `/nw-usage` command to check your energy consumption from within OpenCode.
+A `/nw-usage` command is included in the auto-generated config. To use it:
 
 **1. Install the script** (see [scripts/README.md](../../scripts/)):
 
@@ -58,24 +102,11 @@ Add a `/nw-usage` command to check your energy consumption from within OpenCode.
 ln -s /path/to/neuralwatt-tools/scripts/nw-usage ~/.local/bin/nw-usage
 ```
 
-**2. Add the command** to your `~/.config/opencode/opencode.json`:
-
-```json
-{
-  "command": {
-    "nw-usage": {
-      "description": "Show Neuralwatt energy usage",
-      "template": "Here is my Neuralwatt API usage:\n\n!`nw-usage`\n\nReport this to the user."
-    }
-  }
-}
-```
-
-**3. Use it** by typing `/nw-usage` in OpenCode.
+**2. Use it** by typing `/nw-usage` in OpenCode.
 
 ### Alternative: Markdown file
 
-Instead of JSON config, create `.opencode/command/nw-usage.md` in your project:
+Instead of the JSON config command, create `.opencode/command/nw-usage.md` in your project:
 
 ```markdown
 ---

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -153,15 +153,25 @@ nw-opencode-config --default MODEL_ID     # Set default model
 
 ### Config merging
 
-OpenCode merges configs from multiple sources (global + project + env), so running `--write` adds the Neuralwatt provider without affecting your other providers or settings. Re-running updates the Neuralwatt models to match the current API.
+Re-running `--write` refreshes the Neuralwatt model list to match the current API. The script distinguishes facts it owns from opinions the user owns:
+
+| Field | Behavior on re-run |
+|-|-|
+| `provider.neuralwatt.models` | Replaced wholesale (stale models removed) |
+| `provider.neuralwatt.options` (baseURL, apiKey) | Deep-merged; existing values win |
+| `.model` | Preserved; only set when `--default` passed or field is missing |
+| `command.nw-usage` | Preserved if already defined; added if missing |
+| Other providers, commands, top-level keys | Untouched |
 
 ### Default model
 
-Defaults to `Qwen/Qwen3.5-397B-A17B-FP8`. Override with `--default`:
+First `--write` sets the default to `Qwen/Qwen3.5-397B-A17B-FP8`. Subsequent runs leave `.model` alone unless you pass `--default`:
 
 ```bash
 nw-opencode-config --write --default zai-org/GLM-5.1-FP8
 ```
+
+`--default` is validated against the live API — typos fail fast instead of producing a broken config.
 
 ### Updating
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -121,12 +121,12 @@ The `--color` flag accepts ANSI color codes:
 
 # nw-opencode-config
 
-Generate an [OpenCode](https://opencode.ai) config for Neuralwatt from the live API.
+Print an [OpenCode](https://opencode.ai) config for Neuralwatt to stdout, generated from the live API. **Never writes to your config file** — you redirect the output yourself.
 
 ## Dependencies
 
 - `curl` - for API requests
-- `jq` - for JSON parsing and config merging
+- `jq` - for JSON generation
 
 ## Installation
 
@@ -137,46 +137,42 @@ ln -s /path/to/neuralwatt-tools/scripts/nw-opencode-config ~/.local/bin/
 ## Usage
 
 ```bash
-nw-opencode-config                        # Print config to stdout
-nw-opencode-config --write                # Write to ~/.config/opencode/opencode.json
-nw-opencode-config --models-only          # Print just the models block
-nw-opencode-config --list                 # List available models
+nw-opencode-config                        # Full opencode.json to stdout
+nw-opencode-config --models-only          # Just the models block
+nw-opencode-config --list                 # List available models (human-readable)
 nw-opencode-config --include-aliases      # Include alias/fast models
-nw-opencode-config --default MODEL_ID     # Set default model
+nw-opencode-config --default MODEL_ID     # Override default in output
 ```
 
 ### How it works
 
 1. Fetches model IDs and context limits from `https://api.neuralwatt.com/v1/models`
 2. Merges with curated metadata (`opencode-models.json`) for display names, output limits, and model-specific options
-3. Outputs a valid `opencode.json` — context limits from the API, output limits from metadata
+3. Prints a valid `opencode.json` to stdout
 
-### Config merging
+### Writing the output
 
-Re-running `--write` refreshes the Neuralwatt model list to match the current API. The script distinguishes facts it owns from opinions the user owns:
+Fresh install — redirect directly:
 
-| Field | Behavior on re-run |
-|-|-|
-| `provider.neuralwatt.models` | Replaced wholesale (stale models removed) |
-| `provider.neuralwatt.options` (baseURL, apiKey) | Deep-merged; existing values win |
-| `.model` | Preserved; only set when `--default` passed or field is missing |
-| `command.nw-usage` | Preserved if already defined; added if missing |
-| Other providers, commands, top-level keys | Untouched |
+```bash
+nw-opencode-config > ~/.config/opencode/opencode.json
+```
+
+Existing config — generate the models block and merge by hand:
+
+```bash
+nw-opencode-config --models-only | pbcopy
+# then paste under provider.neuralwatt.models in your existing config
+```
+
+The script deliberately does not touch your config file. That keeps it a pure generator with no merge logic to go wrong.
 
 ### Default model
 
-First `--write` sets the default to `Qwen/Qwen3.5-397B-A17B-FP8`. Subsequent runs leave `.model` alone unless you pass `--default`:
+Defaults to `Qwen/Qwen3.5-397B-A17B-FP8`. Override with `--default`:
 
 ```bash
-nw-opencode-config --write --default zai-org/GLM-5.1-FP8
+nw-opencode-config --default zai-org/GLM-5.1-FP8 > opencode.json
 ```
 
-`--default` is validated against the live API — typos fail fast instead of producing a broken config.
-
-### Updating
-
-When new models are added to the Neuralwatt API, re-run to update your config:
-
-```bash
-nw-opencode-config --write
-```
+`--default` is validated against the live API — typos fail fast.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,11 @@
-# nw-usage
+# Scripts
 
-CLI for checking your Neuralwatt API usage and energy consumption.
+- **nw-usage** — Check your Neuralwatt API usage and energy consumption
+- **nw-opencode-config** — Generate OpenCode config from the live Neuralwatt API
+
+---
+
+# nw-usage
 
 ## Dependencies
 
@@ -111,3 +116,57 @@ The `--color` flag accepts ANSI color codes:
 - **Claude Code statusline**: See [recipes/claude-code/](../recipes/claude-code/)
 - **Tmux statusline**: See [recipes/tmux/](../recipes/tmux/)
 - **OpenCode**: See [recipes/opencode/](../recipes/opencode/)
+
+---
+
+# nw-opencode-config
+
+Generate an [OpenCode](https://opencode.ai) config for Neuralwatt from the live API.
+
+## Dependencies
+
+- `curl` - for API requests
+- `jq` - for JSON parsing and config merging
+
+## Installation
+
+```bash
+ln -s /path/to/neuralwatt-tools/scripts/nw-opencode-config ~/.local/bin/
+```
+
+## Usage
+
+```bash
+nw-opencode-config                        # Print config to stdout
+nw-opencode-config --write                # Write to ~/.config/opencode/opencode.json
+nw-opencode-config --models-only          # Print just the models block
+nw-opencode-config --list                 # List available models
+nw-opencode-config --include-aliases      # Include alias/fast models
+nw-opencode-config --default MODEL_ID     # Set default model
+```
+
+### How it works
+
+1. Fetches model IDs and context limits from `https://api.neuralwatt.com/v1/models`
+2. Merges with curated metadata (`opencode-models.json`) for display names, output limits, and model-specific options
+3. Outputs a valid `opencode.json` — context limits from the API, output limits from metadata
+
+### Config merging
+
+OpenCode merges configs from multiple sources (global + project + env), so running `--write` adds the Neuralwatt provider without affecting your other providers or settings. Re-running updates the Neuralwatt models to match the current API.
+
+### Default model
+
+Defaults to `Qwen/Qwen3.5-397B-A17B-FP8`. Override with `--default`:
+
+```bash
+nw-opencode-config --write --default zai-org/GLM-5.1-FP8
+```
+
+### Updating
+
+When new models are added to the Neuralwatt API, re-run to update your config:
+
+```bash
+nw-opencode-config --write
+```

--- a/scripts/nw-opencode-config
+++ b/scripts/nw-opencode-config
@@ -3,21 +3,19 @@
 #
 # Fetches available models from https://api.neuralwatt.com/v1/models,
 # merges with curated metadata (display names, output limits, model options),
-# and outputs an opencode.json config or just the models block.
+# and prints a valid opencode.json to stdout.
 #
-# Ownership model:
-#   Script owns facts (model list, context limits from API).
-#   User owns opinions (default model, command wording, baseURL overrides).
-# Re-running refreshes facts only — .model and existing commands are preserved
-# unless --default is passed (or the field is missing entirely).
+# This script never writes to your config file. Redirect stdout yourself:
+#   nw-opencode-config > ~/.config/opencode/opencode.json
+# Or copy just the models block into an existing config:
+#   nw-opencode-config --models-only | pbcopy
 #
 # Usage:
-#   nw-opencode-config                    # Print full opencode.json to stdout
-#   nw-opencode-config --models-only      # Print just the models block
-#   nw-opencode-config --write            # Write to ~/.config/opencode/opencode.json
-#   nw-opencode-config --write --default MODEL_ID  # Set default model
-#   nw-opencode-config --list             # List available models (no config output)
+#   nw-opencode-config                    # Full opencode.json to stdout
+#   nw-opencode-config --models-only      # Just the models block
+#   nw-opencode-config --list             # List available models (human-readable)
 #   nw-opencode-config --include-aliases  # Include alias models (e.g., glm-5-fast)
+#   nw-opencode-config --default MODEL_ID # Override default model in output
 #   nw-opencode-config --help
 
 set -euo pipefail
@@ -25,30 +23,24 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 METADATA_FILE="$SCRIPT_DIR/opencode-models.json"
 API_BASE="https://api.neuralwatt.com/v1"
-OPENCODE_GLOBAL_CONFIG="${OPENCODE_CONFIG_FILE:-$HOME/.config/opencode/opencode.json}"
 DEFAULT_MODEL="Qwen/Qwen3.5-397B-A17B-FP8"
 
-# Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
-log_info()  { echo -e "${GREEN}✓${NC} $1"; }
+log_info()  { echo -e "${GREEN}✓${NC} $1" >&2; }
 log_warn()  { echo -e "${YELLOW}!${NC} $1" >&2; }
 log_error() { echo -e "${RED}✗${NC} $1" >&2; }
 
-# Defaults
 MODE="full"
 INCLUDE_ALIASES=false
 USER_DEFAULT=""
-WRITE=false
 
-# Parse args
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --models-only)      MODE="models"; shift ;;
-    --write)            WRITE=true; shift ;;
     --list)             MODE="list"; shift ;;
     --include-aliases)  INCLUDE_ALIASES=true; shift ;;
     --default)          USER_DEFAULT="${2:-}"; shift 2 ;;
@@ -56,32 +48,31 @@ while [[ $# -gt 0 ]]; do
       cat <<'HELP'
 Usage: nw-opencode-config [OPTIONS]
 
-Generate OpenCode config for Neuralwatt from the live API.
+Generate an OpenCode config for Neuralwatt from the live API and print it
+to stdout. This script never modifies your config file — redirect stdout
+yourself to save the output.
 
 Options:
   --models-only        Print only the provider.neuralwatt.models block
-  --write              Write config to ~/.config/opencode/opencode.json (merges,
-                       see merge rules below)
-  --list               List available models from the API (no config output)
+                       (useful for merging into an existing config)
+  --list               List available models (human-readable, not JSON)
   --include-aliases    Include alias/fast models (e.g., glm-5-fast)
-  --default MODEL_ID   Set the default model. On first write uses
-                       Qwen/Qwen3.5-397B-A17B-FP8; on re-run preserves your
-                       existing .model unless this flag is passed.
+  --default MODEL_ID   Set the default model in the generated config
+                       (default: Qwen/Qwen3.5-397B-A17B-FP8)
   -h, --help           Show this help message
 
-Merge rules for --write:
-  provider.neuralwatt.models     replaced wholesale (script owns model list)
-  provider.neuralwatt.options    deep-merged; existing values win
-  .model                         preserved unless --default passed or missing
-  command.nw-usage               preserved if defined; added if missing
-  Other providers / top keys     untouched
-
 Examples:
-  nw-opencode-config                          # Print config to stdout
-  nw-opencode-config --write                  # Write to config file
-  nw-opencode-config --write --default zai-org/GLM-5.1-FP8
-  nw-opencode-config --models-only | jq .     # Inspect models block
-  nw-opencode-config --list                   # See what's available
+  # Write full config (only safe on a fresh install — overwrites the file)
+  nw-opencode-config > ~/.config/opencode/opencode.json
+
+  # Copy just the models block for manual merge into an existing config
+  nw-opencode-config --models-only | pbcopy
+
+  # Inspect what's available
+  nw-opencode-config --list
+
+  # Pick a different default
+  nw-opencode-config --default zai-org/GLM-5.1-FP8 > opencode.json
 HELP
       exit 0
       ;;
@@ -89,7 +80,6 @@ HELP
   esac
 done
 
-# Check dependencies
 if ! command -v jq &>/dev/null; then
   log_error "jq is required but not installed."
   echo "  Install with: brew install jq" >&2
@@ -101,14 +91,12 @@ if ! command -v curl &>/dev/null; then
   exit 1
 fi
 
-# Load metadata
 if [[ ! -f "$METADATA_FILE" ]]; then
   log_error "Model metadata file not found: $METADATA_FILE"
   exit 1
 fi
 METADATA=$(cat "$METADATA_FILE")
 
-# Get API key
 API_KEY=""
 if [[ -n "${NEURALWATT_API_KEY:-}" ]]; then
   API_KEY="$NEURALWATT_API_KEY"
@@ -130,7 +118,7 @@ HTTP_CODE=$(curl -sS -o "$BODY_FILE" -w '%{http_code}' \
 
 if [[ "$HTTP_CODE" != "200" ]]; then
   log_error "API returned HTTP $HTTP_CODE from $API_BASE/models"
-  echo "  Response: $(cat "$BODY_FILE" | head -c 500)" >&2
+  echo "  Response: $(head -c 500 "$BODY_FILE")" >&2
   exit 1
 fi
 
@@ -140,7 +128,6 @@ if ! echo "$DATA" | jq -e '.data' >/dev/null 2>&1; then
   exit 1
 fi
 
-# Filter out aliases unless --include-aliases
 FILTER='.data[] | .id'
 if [[ "$INCLUDE_ALIASES" == "false" ]]; then
   # Alias models don't contain a / (e.g., "glm-5-fast" vs "zai-org/GLM-5.1-FP8")
@@ -167,7 +154,7 @@ if [[ -n "$USER_DEFAULT" ]]; then
   fi
 fi
 
-# Fallback if hardcoded DEFAULT_MODEL is gone from API
+# Fall back if hardcoded DEFAULT_MODEL is gone from API
 if [[ -z "$USER_DEFAULT" ]]; then
   FOUND=false
   for mid in "${MODEL_IDS[@]}"; do
@@ -179,7 +166,6 @@ if [[ -z "$USER_DEFAULT" ]]; then
   fi
 fi
 
-# --list mode: just print models and exit
 if [[ "$MODE" == "list" ]]; then
   echo "Available models on Neuralwatt:"
   echo ""
@@ -191,35 +177,26 @@ if [[ "$MODE" == "list" ]]; then
   exit 0
 fi
 
-# Build models JSON block
 MODELS_JSON="{}"
 for mid in "${MODEL_IDS[@]}"; do
-  # Get context length from API
   max_len=$(echo "$DATA" | jq -r ".data[] | select(.id==\"$mid\") | .max_model_len")
-
-  # Get metadata for this model
   meta_name=$(echo "$METADATA" | jq -r ".\"$mid\".name // \"$mid\"")
   meta_output=$(echo "$METADATA" | jq -r ".\"$mid\".output // 8192")
   meta_options=$(echo "$METADATA" | jq -r ".\"$mid\".options // empty")
 
-  # Build model entry
   entry=$(jq -n \
     --arg name "$meta_name" \
     --argjson context "$max_len" \
     --argjson output "$meta_output" \
     '{name: $name, limit: {context: $context, output: $output}}')
 
-  # Add options if present
   if [[ -n "$meta_options" && "$meta_options" != "null" ]]; then
     entry=$(echo "$entry" | jq --argjson opts "$meta_options" '. + {options: $opts}')
   fi
 
-  # Add to models map — jq path with slashes needs escaping
-  # Model IDs like "Qwen/Qwen3.5-397B-A17B-FP8" become nested keys
   MODELS_JSON=$(echo "$MODELS_JSON" | jq --arg mid "$mid" --argjson e "$entry" '. + {($mid): $e}')
 done
 
-# Determine default model
 FINAL_DEFAULT="${USER_DEFAULT:-$DEFAULT_MODEL}"
 
 if [[ "$MODE" == "models" ]]; then
@@ -227,8 +204,7 @@ if [[ "$MODE" == "models" ]]; then
   exit 0
 fi
 
-# Build full config
-CONFIG=$(jq -n \
+jq -n \
   --arg model "neuralwatt/$FINAL_DEFAULT" \
   --argjson models "$MODELS_JSON" \
   '{
@@ -243,77 +219,11 @@ CONFIG=$(jq -n \
           apiKey: "{env:NEURALWATT_API_KEY}"
         }
       }
+    },
+    command: {
+      "nw-usage": {
+        description: "Show Neuralwatt energy usage",
+        template: "Here is my Neuralwatt API usage:\n\n!`nw-usage`\n\nReport this to the user."
+      }
     }
-  }')
-
-# Also add nw-usage command if not already present
-COMMAND_JSON='{
-  "command": {
-    "nw-usage": {
-      "description": "Show Neuralwatt energy usage",
-      "template": "Here is my Neuralwatt API usage:\n\n!`nw-usage`\n\nReport this to the user."
-    }
-  }
-}'
-CONFIG=$(echo "$CONFIG" "$COMMAND_JSON" | jq -s '.[0] * .[1]')
-
-if [[ "$WRITE" == "true" ]]; then
-  CONFIG_DIR="$(dirname "$OPENCODE_GLOBAL_CONFIG")"
-  mkdir -p "$CONFIG_DIR"
-
-  # Flag: did the user pass --default explicitly?
-  if [[ -n "$USER_DEFAULT" ]]; then
-    EXPLICIT_DEFAULT=true
-  else
-    EXPLICIT_DEFAULT=false
-  fi
-
-  if [[ -f "$OPENCODE_GLOBAL_CONFIG" ]]; then
-    # Merge rules:
-    #   - provider.neuralwatt.models: REPLACE wholesale (script owns model list).
-    #   - provider.neuralwatt other fields (name, npm, options): deep-merge, existing wins on scalar conflicts.
-    #   - .model: preserve existing unless --default passed or field missing.
-    #   - command.nw-usage: preserve existing unless missing.
-    #   - All other keys in existing config: untouched.
-    TEMP_FILE=$(mktemp)
-    if jq -s --argjson explicit "$EXPLICIT_DEFAULT" '
-      .[0] as $existing |
-      .[1] as $new |
-      $existing
-      | (if $explicit or (.model // null) == null
-         then .model = $new.model
-         else . end)
-      | .provider //= {}
-      | .provider.neuralwatt = (
-          ((.provider.neuralwatt // {}) * ($new.provider.neuralwatt | del(.models)))
-          + {models: $new.provider.neuralwatt.models}
-        )
-      | .command //= {}
-      | (if (.command["nw-usage"] // null) == null
-         then .command["nw-usage"] = $new.command["nw-usage"]
-         else . end)
-    ' "$OPENCODE_GLOBAL_CONFIG" <(echo "$CONFIG") > "$TEMP_FILE"; then
-      mv "$TEMP_FILE" "$OPENCODE_GLOBAL_CONFIG"
-      log_info "Merged Neuralwatt config into $OPENCODE_GLOBAL_CONFIG"
-      if [[ "$EXPLICIT_DEFAULT" == "true" ]]; then
-        log_info "Default model: $FINAL_DEFAULT"
-      else
-        EXISTING_DEFAULT=$(jq -r '.model // "(none)"' "$OPENCODE_GLOBAL_CONFIG")
-        log_info "Default model preserved: $EXISTING_DEFAULT"
-      fi
-    else
-      rm -f "$TEMP_FILE"
-      log_error "Failed to merge config"
-      exit 1
-    fi
-  else
-    echo "$CONFIG" > "$OPENCODE_GLOBAL_CONFIG"
-    log_info "Created $OPENCODE_GLOBAL_CONFIG"
-    log_info "Default model: $FINAL_DEFAULT"
-  fi
-  log_info "Models available: ${#MODEL_IDS[@]}"
-  echo ""
-  echo "Run 'opencode' to start."
-else
-  echo "$CONFIG" | jq .
-fi
+  }'

--- a/scripts/nw-opencode-config
+++ b/scripts/nw-opencode-config
@@ -1,0 +1,246 @@
+#!/bin/bash
+# Generate OpenCode config for Neuralwatt from the live API
+#
+# Fetches available models from https://api.neuralwatt.com/v1/models,
+# merges with curated metadata (display names, output limits, model options),
+# and outputs an opencode.json config or just the models block.
+#
+# OpenCode merges configs from multiple sources (global + project + env),
+# so this script only writes the neuralwatt provider block — it won't
+# overwrite your other providers or settings.
+#
+# Usage:
+#   nw-opencode-config                    # Print full opencode.json to stdout
+#   nw-opencode-config --models-only      # Print just the models block
+#   nw-opencode-config --write            # Write to ~/.config/opencode/opencode.json
+#   nw-opencode-config --write --default MODEL_ID  # Set default model
+#   nw-opencode-config --list             # List available models (no config output)
+#   nw-opencode-config --include-aliases  # Include alias models (e.g., glm-5-fast)
+#   nw-opencode-config --help
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+METADATA_FILE="$SCRIPT_DIR/opencode-models.json"
+API_BASE="https://api.neuralwatt.com/v1"
+OPENCODE_GLOBAL_CONFIG="${OPENCODE_CONFIG_FILE:-$HOME/.config/opencode/opencode.json}"
+DEFAULT_MODEL="Qwen/Qwen3.5-397B-A17B-FP8"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info()  { echo -e "${GREEN}✓${NC} $1"; }
+log_warn()  { echo -e "${YELLOW}!${NC} $1"; }
+log_error() { echo -e "${RED}✗${NC} $1" >&2; }
+
+# Defaults
+MODE="full"
+INCLUDE_ALIASES=false
+USER_DEFAULT=""
+WRITE=false
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --models-only)      MODE="models"; shift ;;
+    --write)            WRITE=true; shift ;;
+    --list)             MODE="list"; shift ;;
+    --include-aliases)  INCLUDE_ALIASES=true; shift ;;
+    --default)          USER_DEFAULT="${2:-}"; shift 2 ;;
+    -h|--help)
+      cat <<'HELP'
+Usage: nw-opencode-config [OPTIONS]
+
+Generate OpenCode config for Neuralwatt from the live API.
+
+Options:
+  --models-only        Print only the provider.neuralwatt.models block
+  --write              Write config to ~/.config/opencode/opencode.json (merges,
+                       does not overwrite other providers or settings)
+  --list               List available models from the API (no config output)
+  --include-aliases    Include alias/fast models (e.g., glm-5-fast)
+  --default MODEL_ID   Set the default model (default: Qwen/Qwen3.5-397B-A17B-FP8)
+  -h, --help           Show this help message
+
+OpenCode merges configs, so running with --write will add the Neuralwatt
+provider without affecting your other providers or settings.
+
+Examples:
+  nw-opencode-config                          # Print config to stdout
+  nw-opencode-config --write                  # Write to config file
+  nw-opencode-config --write --default zai-org/GLM-5.1-FP8
+  nw-opencode-config --models-only | jq .     # Inspect models block
+  nw-opencode-config --list                   # See what's available
+HELP
+      exit 0
+      ;;
+    *) log_error "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+# Check dependencies
+if ! command -v jq &>/dev/null; then
+  log_error "jq is required but not installed."
+  echo "  Install with: brew install jq" >&2
+  exit 1
+fi
+
+if ! command -v curl &>/dev/null; then
+  log_error "curl is required but not installed."
+  exit 1
+fi
+
+# Load metadata
+if [[ ! -f "$METADATA_FILE" ]]; then
+  log_error "Model metadata file not found: $METADATA_FILE"
+  exit 1
+fi
+METADATA=$(cat "$METADATA_FILE")
+
+# Get API key
+API_KEY=""
+if [[ -n "${NEURALWATT_API_KEY:-}" ]]; then
+  API_KEY="$NEURALWATT_API_KEY"
+elif [[ -f "${NEURALWATT_API_KEY_FILE:-$HOME/.config/neuralwatt/api_key}" ]]; then
+  API_KEY=$(cat "${NEURALWATT_API_KEY_FILE:-$HOME/.config/neuralwatt/api_key}")
+else
+  log_error "No API key found. Set NEURALWATT_API_KEY or create ~/.config/neuralwatt/api_key"
+  exit 1
+fi
+
+# Fetch models from API
+DATA=$(curl -s -H "Authorization: Bearer $API_KEY" "$API_BASE/models" 2>/dev/null)
+
+if [[ -z "$DATA" ]] || ! echo "$DATA" | jq -e '.data' >/dev/null 2>&1; then
+  log_error "Failed to fetch models from $API_BASE/models"
+  exit 1
+fi
+
+# Filter out aliases unless --include-aliases
+FILTER='.data[] | .id'
+if [[ "$INCLUDE_ALIASES" == "false" ]]; then
+  # Alias models don't contain a / (e.g., "glm-5-fast" vs "zai-org/GLM-5.1-FP8")
+  FILTER='.data[] | select(.id | test("/")) | .id'
+fi
+
+MODEL_IDS=($(echo "$DATA" | jq -r "$FILTER" | sort))
+if [[ ${#MODEL_IDS[@]} -eq 0 ]]; then
+  log_error "No models found from API"
+  exit 1
+fi
+
+# --list mode: just print models and exit
+if [[ "$MODE" == "list" ]]; then
+  echo "Available models on Neuralwatt:"
+  echo ""
+  for mid in "${MODEL_IDS[@]}"; do
+    max_len=$(echo "$DATA" | jq -r ".data[] | select(.id==\"$mid\") | .max_model_len")
+    display_name=$(echo "$METADATA" | jq -r ".\"$mid\".name // \"$mid\"")
+    printf "  %-45s  ctx: %s  %s\n" "$mid" "$max_len" "$display_name"
+  done
+  exit 0
+fi
+
+# Build models JSON block
+MODELS_JSON="{}"
+for mid in "${MODEL_IDS[@]}"; do
+  # Get context length from API
+  max_len=$(echo "$DATA" | jq -r ".data[] | select(.id==\"$mid\") | .max_model_len")
+
+  # Get metadata for this model
+  meta_name=$(echo "$METADATA" | jq -r ".\"$mid\".name // \"$mid\"")
+  meta_output=$(echo "$METADATA" | jq -r ".\"$mid\".output // 8192")
+  meta_options=$(echo "$METADATA" | jq -r ".\"$mid\".options // empty")
+
+  # Build model entry
+  entry=$(jq -n \
+    --arg name "$meta_name" \
+    --argjson context "$max_len" \
+    --argjson output "$meta_output" \
+    '{name: $name, limit: {context: $context, output: $output}}')
+
+  # Add options if present
+  if [[ -n "$meta_options" && "$meta_options" != "null" ]]; then
+    entry=$(echo "$entry" | jq --argjson opts "$meta_options" '. + {options: $opts}')
+  fi
+
+  # Add to models map — jq path with slashes needs escaping
+  # Model IDs like "Qwen/Qwen3.5-397B-A17B-FP8" become nested keys
+  MODELS_JSON=$(echo "$MODELS_JSON" | jq --arg mid "$mid" --argjson e "$entry" '. + {($mid): $e}')
+done
+
+# Determine default model
+FINAL_DEFAULT="${USER_DEFAULT:-$DEFAULT_MODEL}"
+
+if [[ "$MODE" == "models" ]]; then
+  echo "$MODELS_JSON" | jq .
+  exit 0
+fi
+
+# Build full config
+CONFIG=$(jq -n \
+  --arg model "neuralwatt/$FINAL_DEFAULT" \
+  --argjson models "$MODELS_JSON" \
+  '{
+    model: $model,
+    provider: {
+      neuralwatt: {
+        name: "Neuralwatt",
+        npm: "@ai-sdk/openai-compatible",
+        models: $models,
+        options: {
+          baseURL: "https://api.neuralwatt.com/v1",
+          apiKey: "{env:NEURALWATT_API_KEY}"
+        }
+      }
+    }
+  }')
+
+# Also add nw-usage command if not already present
+COMMAND_JSON='{
+  "command": {
+    "nw-usage": {
+      "description": "Show Neuralwatt energy usage",
+      "template": "Here is my Neuralwatt API usage:\n\n!`nw-usage`\n\nReport this to the user."
+    }
+  }
+}'
+CONFIG=$(echo "$CONFIG" "$COMMAND_JSON" | jq -s '.[0] * .[1]')
+
+if [[ "$WRITE" == "true" ]]; then
+  CONFIG_DIR="$(dirname "$OPENCODE_GLOBAL_CONFIG")"
+  mkdir -p "$CONFIG_DIR"
+
+  if [[ -f "$OPENCODE_GLOBAL_CONFIG" ]]; then
+    # Merge — only overwrite the neuralwatt provider, preserve everything else
+    # OpenCode uses nested merge, so we do a deep merge of provider.neuralwatt
+    TEMP_FILE=$(mktemp)
+    if jq -s '
+      .[0] as $existing |
+      .[1] as $new |
+      $existing |
+      .model = $new.model |
+      .provider = (.provider // {} | . * $new.provider) |
+      .command = (.command // {} | . * $new.command)
+    ' "$OPENCODE_GLOBAL_CONFIG" <(echo "$CONFIG") > "$TEMP_FILE"; then
+      mv "$TEMP_FILE" "$OPENCODE_GLOBAL_CONFIG"
+      log_info "Merged Neuralwatt config into $OPENCODE_GLOBAL_CONFIG"
+    else
+      rm -f "$TEMP_FILE"
+      log_error "Failed to merge config"
+      exit 1
+    fi
+  else
+    echo "$CONFIG" > "$OPENCODE_GLOBAL_CONFIG"
+    log_info "Created $OPENCODE_GLOBAL_CONFIG"
+  fi
+  log_info "Default model: $FINAL_DEFAULT"
+  log_info "Models available: ${#MODEL_IDS[@]}"
+  echo ""
+  echo "Run 'opencode' to start."
+else
+  echo "$CONFIG" | jq .
+fi

--- a/scripts/nw-opencode-config
+++ b/scripts/nw-opencode-config
@@ -5,9 +5,11 @@
 # merges with curated metadata (display names, output limits, model options),
 # and outputs an opencode.json config or just the models block.
 #
-# OpenCode merges configs from multiple sources (global + project + env),
-# so this script only writes the neuralwatt provider block — it won't
-# overwrite your other providers or settings.
+# Ownership model:
+#   Script owns facts (model list, context limits from API).
+#   User owns opinions (default model, command wording, baseURL overrides).
+# Re-running refreshes facts only — .model and existing commands are preserved
+# unless --default is passed (or the field is missing entirely).
 #
 # Usage:
 #   nw-opencode-config                    # Print full opencode.json to stdout
@@ -33,7 +35,7 @@ YELLOW='\033[1;33m'
 NC='\033[0m'
 
 log_info()  { echo -e "${GREEN}✓${NC} $1"; }
-log_warn()  { echo -e "${YELLOW}!${NC} $1"; }
+log_warn()  { echo -e "${YELLOW}!${NC} $1" >&2; }
 log_error() { echo -e "${RED}✗${NC} $1" >&2; }
 
 # Defaults
@@ -59,14 +61,20 @@ Generate OpenCode config for Neuralwatt from the live API.
 Options:
   --models-only        Print only the provider.neuralwatt.models block
   --write              Write config to ~/.config/opencode/opencode.json (merges,
-                       does not overwrite other providers or settings)
+                       see merge rules below)
   --list               List available models from the API (no config output)
   --include-aliases    Include alias/fast models (e.g., glm-5-fast)
-  --default MODEL_ID   Set the default model (default: Qwen/Qwen3.5-397B-A17B-FP8)
+  --default MODEL_ID   Set the default model. On first write uses
+                       Qwen/Qwen3.5-397B-A17B-FP8; on re-run preserves your
+                       existing .model unless this flag is passed.
   -h, --help           Show this help message
 
-OpenCode merges configs, so running with --write will add the Neuralwatt
-provider without affecting your other providers or settings.
+Merge rules for --write:
+  provider.neuralwatt.models     replaced wholesale (script owns model list)
+  provider.neuralwatt.options    deep-merged; existing values win
+  .model                         preserved unless --default passed or missing
+  command.nw-usage               preserved if defined; added if missing
+  Other providers / top keys     untouched
 
 Examples:
   nw-opencode-config                          # Print config to stdout
@@ -111,11 +119,24 @@ else
   exit 1
 fi
 
-# Fetch models from API
-DATA=$(curl -s -H "Authorization: Bearer $API_KEY" "$API_BASE/models" 2>/dev/null)
+# Fetch models from API — surface HTTP errors explicitly
+BODY_FILE=$(mktemp)
+trap 'rm -f "$BODY_FILE"' EXIT
+HTTP_CODE=$(curl -sS -o "$BODY_FILE" -w '%{http_code}' \
+  -H "Authorization: Bearer $API_KEY" "$API_BASE/models" 2>&1) || {
+  log_error "curl failed: $HTTP_CODE"
+  exit 1
+}
 
-if [[ -z "$DATA" ]] || ! echo "$DATA" | jq -e '.data' >/dev/null 2>&1; then
-  log_error "Failed to fetch models from $API_BASE/models"
+if [[ "$HTTP_CODE" != "200" ]]; then
+  log_error "API returned HTTP $HTTP_CODE from $API_BASE/models"
+  echo "  Response: $(cat "$BODY_FILE" | head -c 500)" >&2
+  exit 1
+fi
+
+DATA=$(cat "$BODY_FILE")
+if ! echo "$DATA" | jq -e '.data' >/dev/null 2>&1; then
+  log_error "Unexpected response shape from $API_BASE/models (no .data field)"
   exit 1
 fi
 
@@ -126,10 +147,36 @@ if [[ "$INCLUDE_ALIASES" == "false" ]]; then
   FILTER='.data[] | select(.id | test("/")) | .id'
 fi
 
-MODEL_IDS=($(echo "$DATA" | jq -r "$FILTER" | sort))
+mapfile -t MODEL_IDS < <(echo "$DATA" | jq -r "$FILTER" | sort)
 if [[ ${#MODEL_IDS[@]} -eq 0 ]]; then
   log_error "No models found from API"
   exit 1
+fi
+
+# Validate --default against API response
+if [[ -n "$USER_DEFAULT" ]]; then
+  FOUND=false
+  for mid in "${MODEL_IDS[@]}"; do
+    [[ "$mid" == "$USER_DEFAULT" ]] && FOUND=true && break
+  done
+  if [[ "$FOUND" == "false" ]]; then
+    log_error "Model '$USER_DEFAULT' not in API response."
+    echo "  Available models (run with --list for details):" >&2
+    printf '    %s\n' "${MODEL_IDS[@]}" >&2
+    exit 1
+  fi
+fi
+
+# Fallback if hardcoded DEFAULT_MODEL is gone from API
+if [[ -z "$USER_DEFAULT" ]]; then
+  FOUND=false
+  for mid in "${MODEL_IDS[@]}"; do
+    [[ "$mid" == "$DEFAULT_MODEL" ]] && FOUND=true && break
+  done
+  if [[ "$FOUND" == "false" ]]; then
+    log_warn "Hardcoded default '$DEFAULT_MODEL' missing from API. Falling back to '${MODEL_IDS[0]}'."
+    DEFAULT_MODEL="${MODEL_IDS[0]}"
+  fi
 fi
 
 # --list mode: just print models and exit
@@ -214,20 +261,46 @@ if [[ "$WRITE" == "true" ]]; then
   CONFIG_DIR="$(dirname "$OPENCODE_GLOBAL_CONFIG")"
   mkdir -p "$CONFIG_DIR"
 
+  # Flag: did the user pass --default explicitly?
+  if [[ -n "$USER_DEFAULT" ]]; then
+    EXPLICIT_DEFAULT=true
+  else
+    EXPLICIT_DEFAULT=false
+  fi
+
   if [[ -f "$OPENCODE_GLOBAL_CONFIG" ]]; then
-    # Merge — only overwrite the neuralwatt provider, preserve everything else
-    # OpenCode uses nested merge, so we do a deep merge of provider.neuralwatt
+    # Merge rules:
+    #   - provider.neuralwatt.models: REPLACE wholesale (script owns model list).
+    #   - provider.neuralwatt other fields (name, npm, options): deep-merge, existing wins on scalar conflicts.
+    #   - .model: preserve existing unless --default passed or field missing.
+    #   - command.nw-usage: preserve existing unless missing.
+    #   - All other keys in existing config: untouched.
     TEMP_FILE=$(mktemp)
-    if jq -s '
+    if jq -s --argjson explicit "$EXPLICIT_DEFAULT" '
       .[0] as $existing |
       .[1] as $new |
-      $existing |
-      .model = $new.model |
-      .provider = (.provider // {} | . * $new.provider) |
-      .command = (.command // {} | . * $new.command)
+      $existing
+      | (if $explicit or (.model // null) == null
+         then .model = $new.model
+         else . end)
+      | .provider //= {}
+      | .provider.neuralwatt = (
+          ((.provider.neuralwatt // {}) * ($new.provider.neuralwatt | del(.models)))
+          + {models: $new.provider.neuralwatt.models}
+        )
+      | .command //= {}
+      | (if (.command["nw-usage"] // null) == null
+         then .command["nw-usage"] = $new.command["nw-usage"]
+         else . end)
     ' "$OPENCODE_GLOBAL_CONFIG" <(echo "$CONFIG") > "$TEMP_FILE"; then
       mv "$TEMP_FILE" "$OPENCODE_GLOBAL_CONFIG"
       log_info "Merged Neuralwatt config into $OPENCODE_GLOBAL_CONFIG"
+      if [[ "$EXPLICIT_DEFAULT" == "true" ]]; then
+        log_info "Default model: $FINAL_DEFAULT"
+      else
+        EXISTING_DEFAULT=$(jq -r '.model // "(none)"' "$OPENCODE_GLOBAL_CONFIG")
+        log_info "Default model preserved: $EXISTING_DEFAULT"
+      fi
     else
       rm -f "$TEMP_FILE"
       log_error "Failed to merge config"
@@ -236,8 +309,8 @@ if [[ "$WRITE" == "true" ]]; then
   else
     echo "$CONFIG" > "$OPENCODE_GLOBAL_CONFIG"
     log_info "Created $OPENCODE_GLOBAL_CONFIG"
+    log_info "Default model: $FINAL_DEFAULT"
   fi
-  log_info "Default model: $FINAL_DEFAULT"
   log_info "Models available: ${#MODEL_IDS[@]}"
   echo ""
   echo "Run 'opencode' to start."

--- a/scripts/nw-opencode-config
+++ b/scripts/nw-opencode-config
@@ -20,7 +20,15 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve symlinks so METADATA_FILE lookup works when script is symlinked
+# into ~/.local/bin or similar.
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do
+  DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 METADATA_FILE="$SCRIPT_DIR/opencode-models.json"
 API_BASE="https://api.neuralwatt.com/v1"
 DEFAULT_MODEL="Qwen/Qwen3.5-397B-A17B-FP8"

--- a/scripts/opencode-models.json
+++ b/scripts/opencode-models.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "TEMPORARY LOCAL METADATA. Bridge until the Neuralwatt API exposes display names, output limits, and per-model client options natively. Tracked by neuralwatt/inference_frontend#2116 (API extension) and neuralwatt/neuralwatt-tools#19 (unified config generator). Once #2116 lands, nw-opencode-config reads these fields from /v1/models and this file can be deleted.",
   "Qwen/Qwen3.5-397B-A17B-FP8": {
     "name": "Qwen3.5 397B",
     "output": 32768

--- a/scripts/opencode-models.json
+++ b/scripts/opencode-models.json
@@ -1,0 +1,72 @@
+{
+  "Qwen/Qwen3.5-397B-A17B-FP8": {
+    "name": "Qwen3.5 397B",
+    "output": 32768
+  },
+  "Qwen/Qwen3.6-35B-A3B": {
+    "name": "Qwen3.6 35B",
+    "output": 32768
+  },
+  "zai-org/GLM-5.1-FP8": {
+    "name": "GLM-5.1",
+    "output": 131072
+  },
+  "moonshotai/Kimi-K2.5": {
+    "name": "Kimi K2.5",
+    "output": 8192,
+    "options": {
+      "repetitionPenalty": 1.05,
+      "temperature": 0.7,
+      "maxTokens": 4096
+    }
+  },
+  "MiniMaxAI/MiniMax-M2.5": {
+    "name": "MiniMax M2.5",
+    "output": 65536
+  },
+  "mistralai/Devstral-Small-2-24B-Instruct-2512": {
+    "name": "Devstral Small 2",
+    "output": 32768
+  },
+  "openai/gpt-oss-20b": {
+    "name": "GPT-OSS 20B",
+    "output": 8192
+  },
+  "neuralwatt/kimi-k2.5-long": {
+    "name": "Kimi K2.5 Long",
+    "output": 8192,
+    "options": {
+      "repetitionPenalty": 1.05,
+      "temperature": 0.7,
+      "maxTokens": 4096
+    }
+  },
+  "qwen3.6-35b-fast": {
+    "name": "Qwen3.6 35B Fast",
+    "output": 8192
+  },
+  "glm-5-fast": {
+    "name": "GLM-5 Fast",
+    "output": 8192
+  },
+  "kimi-k2.5-fast": {
+    "name": "Kimi K2.5 Fast",
+    "output": 4096,
+    "options": {
+      "repetitionPenalty": 1.05,
+      "temperature": 0.7
+    }
+  },
+  "glm-5.1-fast": {
+    "name": "GLM-5.1 Fast",
+    "output": 8192
+  },
+  "qwen3.5-397b-fast": {
+    "name": "Qwen3.5 397B Fast",
+    "output": 8192
+  },
+  "qwen3.5-35b-fast": {
+    "name": "Qwen3.5 35B Fast",
+    "output": 8192
+  }
+}


### PR DESCRIPTION
## Summary

Adds `scripts/nw-opencode-config` that prints an OpenCode config generated from the live Neuralwatt API. Pure stdout — the script never writes to the user's config file. Updates the OpenCode recipe to recommend the script as the primary setup method.

## Design

Script is a **pure generator**. Emits JSON to stdout. User redirects or copies the output wherever they want:

```bash
nw-opencode-config > ~/.config/opencode/opencode.json   # fresh install
nw-opencode-config --models-only | pbcopy               # manual merge into existing config
nw-opencode-config --list                               # human-readable model list
nw-opencode-config --default zai-org/GLM-5.1-FP8 > ...  # override default
```

Intentionally no `--write` / config-merge feature — writing into arbitrary user configs means ownership rules (which fields does the script own vs. the user?) and merge bugs. Keeping the tool stdout-only eliminates that surface area entirely.

## How it works

1. Fetches model IDs + `max_model_len` from `/v1/models`
2. Fills in display names, output limits, and per-model sampling knobs (e.g. Kimi's `repetitionPenalty`) from `scripts/opencode-models.json`
3. Prints a valid `opencode.json` to stdout

`opencode-models.json` is a **temporary bridge** — see followups below.

## Validation

Tested end-to-end against the live API:
- `--list`: all models with context limits
- `--models-only`: models block only
- `--default <valid>`: overrides default in output
- `--default <bogus>`: fails fast with list of valid IDs
- HTTP error path: 404 surfaces status + response body (no silent fallback)
- Full stdout: valid JSON with `model`, `provider.neuralwatt`, `command.nw-usage`

Closes #17.

## Followups

- **#19** — Unified config generator (opencode, crush, continue, ...). Blocked on `inference_frontend#2116`.
- **`inference_frontend#2116`** — extend `/v1/models` with display names, output limits, and per-model client options. Once this lands, `opencode-models.json` is deleted and the script reads that metadata directly from the API. ([commented asking for a per-model `options` field](https://github.com/neuralwatt/inference_frontend/issues/2116#issuecomment-4291155287) so sampling knobs migrate too.)
- **`inference_frontend#2387`** — register Neuralwatt on models.dev for ecosystem discoverability (longer-term; eventually OpenCode users won't need this script at all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)