### PR TITLE
docs: trim OpenCode and Crush recipes to use built-in providers

### DIFF
--- a/recipes/crush/README.md
+++ b/recipes/crush/README.md
@@ -61,12 +61,13 @@ crush
 3. Filter by "Neuralwatt"
 4. Pick a model
 
-You can also set a default model in `~/.config/crush/crush.json`:
+You can also set defaults in `~/.config/crush/crush.json`. Crush picks a `large` model for primary work and a `small` one for cheaper background tasks:
 
 ```json
 {
   "model": {
-    "large": "Qwen/Qwen3.5-397B-A17B-FP8"
+    "large": "moonshotai/Kimi-K2.6",
+    "small": "Qwen/Qwen3.6-35B-A3B"
   }
 }
 ```

--- a/recipes/opencode/README.md
+++ b/recipes/opencode/README.md
@@ -1,10 +1,10 @@
 # OpenCode with Neuralwatt
 
-[OpenCode](https://opencode.ai) ([GitHub](https://github.com/anomalyco/opencode)) is an AI coding agent CLI that lets you bring your own models.
+[OpenCode](https://opencode.ai) ([GitHub](https://github.com/sst/opencode)) is an AI coding agent CLI. Neuralwatt is a built-in provider in OpenCode's model catalog, so the only thing you need to do is set your API key.
 
 ## Install
 
-See [OpenCode installation docs](https://github.com/anomalyco/opencode?tab=readme-ov-file#installation) for all options, or:
+See [OpenCode installation docs](https://opencode.ai/docs/) for all options, or:
 
 ```bash
 brew install anomalyco/tap/opencode
@@ -12,40 +12,28 @@ brew install anomalyco/tap/opencode
 
 ## Setup
 
-**1. Export your API key** (add to `~/.zshrc`):
+Export your API key (add to `~/.zshrc` or `~/.bashrc`):
 
 ```bash
 export NEURALWATT_API_KEY="your-api-key-here"
 ```
 
-**2. Create config** at `~/.config/opencode/opencode.json`:
-
-```json
-{
-  "model": "neuralwatt/Qwen/Qwen3.5-397B-A17B-FP8",
-  "provider": {
-    "neuralwatt": {
-      "name": "Neuralwatt",
-      "npm": "@ai-sdk/openai-compatible",
-      "models": {
-        "Qwen/Qwen3.5-397B-A17B-FP8": {
-          "name": "Qwen3.5 397B",
-          "limit": { "context": 262144, "output": 32768 }
-        }
-      },
-      "options": {
-        "baseURL": "https://api.neuralwatt.com/v1",
-        "apiKey": "{env:NEURALWATT_API_KEY}"
-      }
-    }
-  }
-}
-```
-
-## Run
+Launch OpenCode:
 
 ```bash
 opencode
+```
+
+Open the model picker (`/models`), filter by "Neuralwatt", and pick a model.
+
+## Set a Default Model
+
+Optional. Add to `~/.config/opencode/opencode.json` (global) or `./opencode.json` (per-project):
+
+```json
+{
+  "model": "neuralwatt/zai-org/GLM-5.1-FP8"
+}
 ```
 
 ## Energy Usage Command


### PR DESCRIPTION
## Summary

Both Crush and OpenCode now ship Neuralwatt as a built-in provider via their respective model catalogs (catwalk for Crush, models.dev for OpenCode). Neither recipe needs the manual provider config block anymore — exporting `NEURALWATT_API_KEY` is enough.

### OpenCode

- Drop the manual `provider.neuralwatt` block from `opencode.json`. It duplicates what models.dev already provides.
- Fix the GitHub link (`anomalyco/opencode` → `sst/opencode`, the canonical repo).
- Show `/models` picker as the discovery path.
- Show how to set a default model via `opencode.json`.
- Energy usage command section unchanged.

### Crush

- Tweak the default-model example to set both `large` and `small`. Crush splits work between them, and the prior example only showed `large`.

## Test plan

- [x] OpenCode picks up Neuralwatt with just `NEURALWATT_API_KEY` set (verified via `curl -s https://models.dev/api.json`)
- [x] Crush picks up Neuralwatt with just `NEURALWATT_API_KEY` set (verified via catwalk's `internal/providers/configs/neuralwatt.json`)
- [ ] Reviewer to sanity-check that the new OpenCode flow works in a clean install