### PR TITLE
docs: trim Kilo Code recipe to use built-in provider

### DIFF
--- a/recipes/kilo-code/README.md
+++ b/recipes/kilo-code/README.md
@@ -1,12 +1,12 @@
 # Kilo Code CLI with Neuralwatt
 
-[Kilo Code](https://kilo.ai) ([GitHub](https://github.com/Kilo-Org/kilocode)) is an open-source AI coding agent with a CLI that supports custom OpenAI-compatible providers.
+[Kilo Code](https://kilo.ai) ([GitHub](https://github.com/Kilo-Org/kilocode)) is an AI coding agent CLI and a fork of [OpenCode](https://opencode.ai). It inherits OpenCode's [models.dev](https://models.dev) catalog, so Neuralwatt is a built-in provider. Set your API key and you're done.
 
 ![Kilo CLI with Neuralwatt](kilo-cli.png)
 
 ## Install
 
-See [Kilo Code installation docs](https://kilo.ai/docs/getting-started/installation) for all options.
+See [Kilo Code installation docs](https://kilo.ai/docs/getting-started/installation) for all options, or:
 
 ```bash
 # npm (all platforms)
@@ -21,64 +21,44 @@ brew install Kilo-Org/tap/kilo
 
 ## Setup
 
-**1. Export your API key** (add to your shell profile):
+Export your API key (add to `~/.zshrc` or `~/.bashrc`):
 
 ```bash
 export NEURALWATT_API_KEY="your-api-key-here"
 ```
 
-**2. Create config** at `~/.config/kilo/kilo.json`:
+Launch Kilo:
+
+```bash
+kilo
+```
+
+Open the model picker (`Ctrl+M`), filter by "Neuralwatt", and pick a model.
+
+## Set a Default Model
+
+Optional. Add to `~/.config/kilo/kilo.json` (global) or `./kilo.json` (per-project):
 
 ```json
 {
-  "model": "neuralwatt/Qwen/Qwen3.5-397B-A17B-FP8",
-  "provider": {
-    "neuralwatt": {
-      "name": "Neuralwatt",
-      "env": ["NEURALWATT_API_KEY"],
-      "options": {
-        "baseURL": "https://api.neuralwatt.com/v1"
-      },
-      "models": {
-        "Qwen/Qwen3.5-397B-A17B-FP8": {
-          "name": "Qwen3.5 397B MoE",
-          "tool_call": true,
-          "limit": { "context": 262144, "output": 32768 }
-        },
-        "Qwen/Qwen3.5-35B-A3B": {
-          "name": "Qwen3.5 35B MoE",
-          "tool_call": true,
-          "limit": { "context": 32768, "output": 8192 }
-        },
-        "moonshotai/Kimi-K2.5": {
-          "name": "Kimi K2.5",
-          "reasoning": true,
-          "tool_call": true,
-          "limit": { "context": 262144, "output": 32768 }
-        },
-        "mistralai/Devstral-Small-2-24B-Instruct-2512": {
-          "name": "Devstral Small 24B",
-          "tool_call": true,
-          "limit": { "context": 262144, "output": 32768 }
-        },
-        "zai-org/GLM-5-FP8": {
-          "name": "GLM-5",
-          "tool_call": true,
-          "limit": { "context": 131072, "output": 32768 }
-        },
-        "MiniMaxAI/MiniMax-M2.5": {
-          "name": "MiniMax M2.5",
-          "tool_call": true,
-          "limit": { "context": 196608, "output": 32768 }
-        },
-        "openai/gpt-oss-20b": {
-          "name": "GPT-OSS 20B",
-          "tool_call": true,
-          "limit": { "context": 16384, "output": 8192 }
-        }
-      }
-    }
-  },
+  "model": "neuralwatt/zai-org/GLM-5-FP8"
+}
+```
+
+## Energy Usage Command
+
+Add a `/nw-usage` command to check your energy consumption from within Kilo.
+
+**1. Install the script** (see [scripts/README.md](../../scripts/)):
+
+```bash
+ln -s /path/to/neuralwatt-tools/scripts/nw-usage ~/.local/bin/nw-usage
+```
+
+**2. Add the command** to your `~/.config/kilo/kilo.json`:
+
+```json
+{
   "command": {
     "nw-usage": {
       "description": "Show Neuralwatt energy usage",
@@ -88,21 +68,4 @@ export NEURALWATT_API_KEY="your-api-key-here"
 }
 ```
 
-Switch models at runtime with `Ctrl+M` or by editing the `"model"` field (format: `neuralwatt/<model-id>`).
-
-## Run
-
-```bash
-kilo
-```
-
-## Energy Usage Command (optional)
-
-The config above already includes a `/nw-usage` command. To use it, install the script:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/neuralwatt/neuralwatt-tools/main/scripts/nw-usage \
-  -o ~/.local/bin/nw-usage && chmod +x ~/.local/bin/nw-usage
-```
-
-Then type `/nw-usage` in Kilo Code.
+**3. Use it** by typing `/nw-usage` in Kilo.


### PR DESCRIPTION
## Summary

Kilo CLI is a fork of OpenCode and inherits its [models.dev](https://models.dev) catalog, which already ships Neuralwatt as a built-in provider. The manual `provider.neuralwatt` block in our recipe is redundant. Exporting `NEURALWATT_API_KEY` is the only required step.

Mirrors the OpenCode trim from #21.

### Changes

- Drop the manual `provider.neuralwatt` config block from the suggested `kilo.json`.
- Update the description to explain *why* no provider block is needed (fork of OpenCode, shares the catalog).
- Show `Ctrl+M` model picker as the discovery path.
- Add a separate optional "Set a Default Model" section, matching the OpenCode recipe.
- Keep the energy-usage `/nw-usage` command as an optional add-on instead of baking it into the giant config.

## Test plan

- [x] Verified locally: with only \`NEURALWATT_API_KEY\` set (no \`~/.config/kilo/kilo.json\`), Kilo's model picker lists Neuralwatt models and they work.
- [ ] Reviewer to sanity-check on a clean install.