### PR TITLE
docs(plugins/pi): warn that an existing neuralwatt provider can shadow the bundled model list

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Get your API key from [portal.neuralwatt.com](https://portal.neuralwatt.com), th
 | [Open WebUI](recipes/open-webui/) | Self-hosted ChatGPT-style web UI | [Setup guide](recipes/open-webui/README.md) |
 | [OpenCode](recipes/opencode/) | AI coding agent CLI | [Setup guide](recipes/opencode/README.md) |
 | [llm plugin](plugins/llm-neuralwatt/) | Use Neuralwatt with [simonw/llm](https://llm.datasette.io/) CLI | [Setup guide](plugins/llm-neuralwatt/README.md) |
+| [Pi MCR extension](plugins/pi/) | Unlock 1M virtual context in [Pi](https://pi.dev) via Neuralwatt MCR | [Setup guide](plugins/pi/README.md) |
 | [Neovim](recipes/neovim/) | AI completions + energy monitor | [Setup guide](recipes/neovim/README.md) |
 | [Tmux](recipes/tmux/) | Show usage in status bar | [Setup guide](recipes/tmux/README.md) |
 
@@ -57,7 +58,8 @@ neuralwatt-tools/
 ├── scripts/
 │   └── nw-usage             # CLI for checking energy usage
 ├── plugins/
-│   └── llm-neuralwatt/      # pip-installable LLM plugin
+│   ├── llm-neuralwatt/      # pip-installable LLM plugin
+│   └── pi/                  # Pi MCR extension (1M virtual context)
 └── recipes/
     ├── claude-code/         # Anthropic's coding CLI setup
     ├── openclaw/            # Personal AI assistant gateway

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Get your API key from [portal.neuralwatt.com](https://portal.neuralwatt.com), th
 | [Open WebUI](recipes/open-webui/) | Self-hosted ChatGPT-style web UI | [Setup guide](recipes/open-webui/README.md) |
 | [OpenCode](recipes/opencode/) | AI coding agent CLI | [Setup guide](recipes/opencode/README.md) |
 | [llm plugin](plugins/llm-neuralwatt/) | Use Neuralwatt with [simonw/llm](https://llm.datasette.io/) CLI | [Setup guide](plugins/llm-neuralwatt/README.md) |
-| [Pi MCR extension](plugins/pi/) | Unlock 1M virtual context in [Pi](https://pi.dev) via Neuralwatt MCR | [Setup guide](plugins/pi/README.md) |
+| [Pi MCR extension](plugins/pi/) *(private beta)* | Unlock 1M virtual context in [Pi](https://pi.dev) via Neuralwatt MCR | [Setup guide](plugins/pi/README.md) |
 | [Neovim](recipes/neovim/) | AI completions + energy monitor | [Setup guide](recipes/neovim/README.md) |
 | [Tmux](recipes/tmux/) | Show usage in status bar | [Setup guide](recipes/tmux/README.md) |
 

--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -4,6 +4,8 @@ A drop-in extension for [Pi](https://pi.dev) that unlocks Neuralwatt's MCR (Mana
 
 The extension works with Neuralwatt's Tier 2 response-header protocol — no Pi core changes, no proxy, no patched build required.
 
+> 🚧 **Private beta.** The MCR long-context aliases (`neuralwatt/kimi-k2.6-long`, `neuralwatt/glm-5.1-long`) are currently in a closed beta. You'll need an access grant on top of a Neuralwatt API key — email **chad@neuralwatt.com** to request one. Once granted, the install steps below work as written; without a grant, calls to the aliases will return 404.
+
 ## What it does
 
 When you select a Neuralwatt MCR model (e.g., `neuralwatt/kimi-k2.6-long`, `neuralwatt/glm-5.1-long`), the extension:

--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -1,0 +1,137 @@
+# Neuralwatt MCR Extension for Pi
+
+A drop-in extension for [Pi](https://pi.dev) that unlocks Neuralwatt's MCR (Managed Context Runtime) long-context models. Get **1M virtual context** through transparent server-side compaction, with on-demand recall of dropped messages via the `mcr_lookup` tool.
+
+The extension works with Neuralwatt's Tier 2 response-header protocol — no Pi core changes, no proxy, no patched build required.
+
+## What it does
+
+When you select a Neuralwatt MCR model (e.g., `neuralwatt/kimi-k2.6-long`, `neuralwatt/glm-5.1-long`), the extension:
+
+- **Context drop** — Reads `X-MCR-Safe-Drop-Before` from response headers and trims old messages the server has already stored, keeping the client bounded while the server maintains a 1M+ virtual context window.
+- **Session fingerprint** — Sends `X-MCR-Session-FP` on subsequent requests so the server can resume the same compacted session directly across turns and auto-compact boundaries.
+- **Compaction suppression** — Cancels Pi's built-in compaction when MCR is active (the server handles it).
+- **Anchor protection** — Preserves the first 3 user messages (MCR's fingerprint anchors) so sessions stay stable.
+- **Energy + MCR status bar** — Adds `nw-mcr` (session fingerprint + current drop threshold) and `nw-energy` (cumulative energy + APC cache hit rate + compaction ratio) to Pi's footer.
+
+## Requirements
+
+- Pi v0.72+
+- A Neuralwatt API key — get one at [portal.neuralwatt.com](https://portal.neuralwatt.com)
+
+## Install
+
+### 1. Set your API key
+
+```bash
+export NEURALWATT_API_KEY=<your-key>
+```
+
+Add this to `~/.bashrc` or `~/.zshrc` so it persists across shells.
+
+### 2. Clone this repo
+
+```bash
+git clone https://github.com/neuralwatt/neuralwatt-tools.git
+```
+
+### 3. Copy the models config
+
+Pi needs to know about Neuralwatt's models. Copy the bundled `models.json` to Pi's config directory:
+
+```bash
+cp neuralwatt-tools/plugins/pi/configs/models.json ~/.pi/agent/models.json
+```
+
+If you already have a `~/.pi/agent/models.json` with other providers, merge the `neuralwatt` provider entry into your existing file instead of overwriting.
+
+### 4. Copy the extension
+
+Pi auto-discovers extensions under `~/.pi/agent/extensions/`:
+
+```bash
+mkdir -p ~/.pi/agent/extensions
+cp neuralwatt-tools/plugins/pi/extensions/neuralwatt-mcr.ts ~/.pi/agent/extensions/
+```
+
+### 5. Launch Pi and pick a model
+
+```bash
+pi
+```
+
+Open the model picker with `/model` (or `Ctrl+L`) and pick one of the MCR long-context entries:
+
+- `neuralwatt/kimi-k2.6-long` — Kimi K2.6 with 1M virtual context
+- `neuralwatt/glm-5.1-long` — GLM 5.1 with 1M virtual context
+
+Standard non-MCR models (e.g., `glm-5-fast`, `kimi-k2.6-fast`) are also listed in `models.json` and work as normal Neuralwatt models — the extension only activates for MCR-capable models.
+
+## Status bar
+
+When you're on an MCR model, two indicators appear in Pi's footer:
+
+| Key | Shows |
+|-----|-------|
+| `nw-mcr` | Session fingerprint (first 8 chars) + current drop threshold |
+| `nw-energy` | Cumulative energy (mJ/J/kJ), APC cache hit rate, compaction ratio |
+
+Example:
+
+```
+MCR a1b2c3d4 | drop<35    nw-energy 2.3J | APC 85% | compact 42%
+```
+
+## How context drop works
+
+```
+Before: [anchor1, anchor2, anchor3, old_msg_4, ..., old_msg_35, recent_36, ..., recent_85]
+After:  [anchor1, anchor2, anchor3, recent_36, ..., recent_85]
+                                    dropped [4..35) — server has them stored
+```
+
+1. Pi sends a request to the Neuralwatt API.
+2. The MCR pipeline compacts old context server-side.
+3. Response headers include `X-MCR-Safe-Drop-Before: 35`.
+4. On the next `context` event (before the next LLM call), the extension drops messages 4–35.
+5. If the model needs anything from a dropped range, it can call the `mcr_lookup` tool and the server retrieves it from its store.
+
+## MCR vs non-MCR models
+
+The extension only activates for MCR-capable models. These are detected by model ID:
+
+- IDs with the `neuralwatt/` prefix (e.g., `neuralwatt/glm-5.1-long`)
+- IDs ending in `-long` (indicates a 1M virtual context window)
+- Base model IDs starting with `zai-org/`, `moonshotai/`, `glm-5`, `kimi-k2`
+
+For non-MCR models the extension stays out of the way — Pi behaves exactly as it does without the extension installed.
+
+## Known caveats
+
+- **`nw-energy` status bar may show `--` during streaming.** Energy data is currently only emitted on the non-streaming response path; the streaming SSE body does not yet include it. The `nw-mcr` indicator works on both paths. This is tracked and expected to be addressed in a future Neuralwatt API update.
+- **If a session ever looks stuck** (no responses, repeated drop events, garbled state), exit Pi and start a fresh session — the server-side MCR state resets per conversation ID.
+- **Token cost shows $0.00.** Intentional. All Neuralwatt models bill by energy, not tokens, so the `cost` fields in `models.json` are zeroed. Use the `nw-energy` status bar (and `nw-usage` CLI in this repo) for actual usage tracking.
+
+## Troubleshooting
+
+- **Extension not loading** — Check that the file is at `~/.pi/agent/extensions/neuralwatt-mcr.ts` and Pi's startup output for parse errors.
+- **No MCR headers in responses** — Only MCR-backed models (the `-long` variants) return MCR headers. Standard models like `glm-5-fast` don't use MCR.
+- **API key not picked up** — `NEURALWATT_API_KEY` must be exported in the shell where you launch `pi`. The models config references the env var by name, so the value is resolved at Pi startup.
+
+## Architecture
+
+```
+Pi extension (neuralwatt-mcr.ts)
+  |
+  +- after_provider_response   reads X-MCR-* headers
+  +- message_end               reads response body mcr/energy (fallback)
+  +- context                   drops messages per safe_drop_before
+  +- before_provider_request   sends X-MCR-Session-FP header
+  +- session_before_compact    cancels Pi compaction when MCR active
+  +- session_start             resets state
+  +- session_shutdown          clears status bar
+```
+
+## Feedback
+
+Found a bug or want to suggest an improvement? Open an issue on this repo or drop into the [Neuralwatt Discord](https://discord.gg/ZJEfU2BZw2).

--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -47,6 +47,8 @@ cp neuralwatt-tools/plugins/pi/configs/models.json ~/.pi/agent/models.json
 
 If you already have a `~/.pi/agent/models.json` with other providers, merge the `neuralwatt` provider entry into your existing file instead of overwriting.
 
+> ⚠️ **Heads up: an existing `neuralwatt` provider can shadow the bundled model list.** If you've previously added a Neuralwatt provider to Pi (via `pi /provider`, a prior `models.json`, or another extension), it can take precedence and the long-context aliases below may not appear in `/model` or may not route correctly. Before copying, check `pi /provider` and `~/.pi/agent/models.json` for an existing `neuralwatt` entry — remove it (or merge the bundled `models` array into it) so the canonical list from this repo is what Pi sees.
+
 ### 4. Copy the extension
 
 Pi auto-discovers extensions under `~/.pi/agent/extensions/`:

--- a/plugins/pi/configs/models.json
+++ b/plugins/pi/configs/models.json
@@ -1,0 +1,345 @@
+{
+  "providers": {
+    "neuralwatt": {
+      "baseUrl": "https://api.neuralwatt.com/v1",
+      "api": "openai-completions",
+      "apiKey": "NEURALWATT_API_KEY",
+      "compat": {
+        "supportsDeveloperRole": false,
+        "supportsReasoningEffort": false,
+        "maxTokensField": "max_tokens"
+      },
+      "models": [
+        {
+          "id": "zai-org/GLM-5.1-FP8",
+          "name": "GLM-5.1",
+          "reasoning": true,
+          "input": [
+            "text"
+          ],
+          "contextWindow": 202752,
+          "maxTokens": 8192,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        },
+        {
+          "id": "glm-5.1-fast",
+          "name": "GLM-5.1 Fast",
+          "reasoning": false,
+          "input": [
+            "text"
+          ],
+          "contextWindow": 202752,
+          "maxTokens": 8192,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        },
+        {
+          "id": "glm-5-fast",
+          "name": "GLM-5 Fast",
+          "reasoning": false,
+          "input": [
+            "text"
+          ],
+          "contextWindow": 202752,
+          "maxTokens": 8192,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        },
+        {
+          "id": "neuralwatt/glm-5-long",
+          "name": "GLM-5 Long (MCR 1M)",
+          "reasoning": true,
+          "input": [
+            "text"
+          ],
+          "contextWindow": 1048576,
+          "maxTokens": 16384,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        },
+        {
+          "id": "neuralwatt/glm-5.1-long",
+          "name": "GLM-5.1 Long (MCR 1M)",
+          "reasoning": true,
+          "input": [
+            "text"
+          ],
+          "contextWindow": 1048576,
+          "maxTokens": 16384,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        },
+        {
+          "id": "neuralwatt/glm-5.1-fast-long",
+          "name": "GLM-5.1 Fast Long (MCR 1M)",
+          "reasoning": false,
+          "input": [
+            "text"
+          ],
+          "contextWindow": 1048576,
+          "maxTokens": 16384,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        },
+        {
+          "id": "moonshotai/Kimi-K2.6",
+          "name": "Kimi K2.6",
+          "reasoning": true,
+          "input": [
+            "text",
+            "image"
+          ],
+          "contextWindow": 262144,
+          "maxTokens": 8192,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        },
+        {
+          "id": "kimi-k2.6-fast",
+          "name": "Kimi K2.6 Fast",
+          "reasoning": false,
+          "input": [
+            "text",
+            "image"
+          ],
+          "contextWindow": 262144,
+          "maxTokens": 8192,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        },
+        {
+          "id": "neuralwatt/kimi-k2.6-long",
+          "name": "Kimi K2.6 Long (MCR 1M)",
+          "reasoning": true,
+          "input": [
+            "text",
+            "image"
+          ],
+          "contextWindow": 1048576,
+          "maxTokens": 16384,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        },
+        {
+          "id": "moonshotai/Kimi-K2.5",
+          "name": "Kimi K2.5",
+          "reasoning": true,
+          "input": [
+            "text",
+            "image"
+          ],
+          "contextWindow": 262144,
+          "maxTokens": 8192,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        },
+        {
+          "id": "kimi-k2.5-fast",
+          "name": "Kimi K2.5 Fast",
+          "reasoning": false,
+          "input": [
+            "text",
+            "image"
+          ],
+          "contextWindow": 262144,
+          "maxTokens": 8192,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        },
+        {
+          "id": "neuralwatt/kimi-k2.5-long",
+          "name": "Kimi K2.5 Long (MCR 1M)",
+          "reasoning": true,
+          "input": [
+            "text",
+            "image"
+          ],
+          "contextWindow": 1048576,
+          "maxTokens": 16384,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        },
+        {
+          "id": "Qwen/Qwen3.6-35B-A3B",
+          "name": "Qwen3.6 35B",
+          "reasoning": true,
+          "input": [
+            "text",
+            "image"
+          ],
+          "contextWindow": 131072,
+          "maxTokens": 8192,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        },
+        {
+          "id": "qwen3.6-35b-fast",
+          "name": "Qwen3.6 35B Fast",
+          "reasoning": false,
+          "input": [
+            "text",
+            "image"
+          ],
+          "contextWindow": 131072,
+          "maxTokens": 8192,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        },
+        {
+          "id": "Qwen/Qwen3.5-397B-A17B-FP8",
+          "name": "Qwen3.5 397B FP8",
+          "reasoning": true,
+          "input": [
+            "text"
+          ],
+          "contextWindow": 262144,
+          "maxTokens": 8192,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        },
+        {
+          "id": "qwen3.5-397b-fast",
+          "name": "Qwen3.5 397B Fast",
+          "reasoning": false,
+          "input": [
+            "text"
+          ],
+          "contextWindow": 262144,
+          "maxTokens": 8192,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        },
+        {
+          "id": "MiniMaxAI/MiniMax-M2.5",
+          "name": "MiniMax M2.5",
+          "reasoning": true,
+          "input": [
+            "text"
+          ],
+          "contextWindow": 196608,
+          "maxTokens": 8192,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        },
+        {
+          "id": "mistralai/Devstral-Small-2-24B-Instruct-2512",
+          "name": "Devstral Small 2 24B",
+          "reasoning": false,
+          "input": [
+            "text",
+            "image"
+          ],
+          "contextWindow": 262144,
+          "maxTokens": 8192,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        },
+        {
+          "id": "openai/gpt-oss-20b",
+          "name": "GPT OSS 20B",
+          "reasoning": true,
+          "input": [
+            "text"
+          ],
+          "contextWindow": 16384,
+          "maxTokens": 8192,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        },
+        {
+          "id": "neuralwatt/claude-opus-cached",
+          "name": "Claude Opus (Cached)",
+          "reasoning": true,
+          "input": [
+            "text"
+          ],
+          "contextWindow": 1000000,
+          "maxTokens": 32000,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        }
+      ]
+    }
+  }
+}

--- a/plugins/pi/extensions/neuralwatt-mcr.ts
+++ b/plugins/pi/extensions/neuralwatt-mcr.ts
@@ -1,0 +1,642 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { randomUUID } from "node:crypto";
+
+const MCR_ANCHOR_USER_MESSAGES = 3;
+
+const LOG_FILE = path.join(
+  os.homedir(),
+  ".pi",
+  "agent",
+  "extensions",
+  "neuralwatt-mcr.log",
+);
+
+function nwlog(event: string, data: Record<string, unknown> = {}): void {
+  try {
+    const line =
+      JSON.stringify({ ts: new Date().toISOString(), event, ...data }) + "\n";
+    fs.appendFileSync(LOG_FILE, line);
+  } catch {
+    // never break the extension on logging failure
+  }
+}
+
+interface MCRMetadata {
+  session_fp: string;
+  stored_through: number;
+  safe_drop_before: number;
+}
+
+interface EnergyData {
+  energy_joules: number;
+  mcr?: {
+    session_turns: number;
+    context_tokens: number;
+    compaction_triggered: boolean;
+    apc_hit_rate?: number;
+    mcr_compacted_tokens?: number;
+    mcr_original_tokens?: number;
+  };
+}
+
+interface SessionState {
+  sessionFp: string | null;
+  safeDropBefore: number;
+  storedThrough: number;
+  totalEnergyJoules: number;
+  sessionTurns: number;
+  contextTokens: number;
+  lastMcrMeta: MCRMetadata | null;
+  lastEnergy: EnergyData | null;
+}
+
+const state: SessionState = {
+  sessionFp: null,
+  safeDropBefore: 0,
+  storedThrough: 0,
+  totalEnergyJoules: 0,
+  sessionTurns: 0,
+  contextTokens: 0,
+  lastMcrMeta: null,
+  lastEnergy: null,
+};
+
+function isMCRModel(modelId: string): boolean {
+  return (
+    modelId.includes("neuralwatt/") ||
+    modelId.includes("-long") ||
+    modelId.startsWith("zai-org/") ||
+    modelId.startsWith("moonshotai/") ||
+    modelId.startsWith("glm-5") ||
+    modelId.startsWith("kimi-k2")
+  );
+}
+
+function extractMCRFromHeaders(
+  headers: Record<string, string>,
+): MCRMetadata | null {
+  const fp = headers["x-mcr-session-fp"];
+  if (!fp) return null;
+  return {
+    session_fp: fp,
+    stored_through: parseInt(headers["x-mcr-stored-through"] || "0", 10),
+    safe_drop_before: parseInt(
+      headers["x-mcr-safe-drop-before"] || "0",
+      10,
+    ),
+  };
+}
+
+// Parse a header value as an integer if present, else null. We keep null
+// distinct from 0 because:
+//   * absent header  -> gateway did not run the M1.b ref-recovery code path
+//     (older deploy, non-MCR request, or path bailed before emitting)
+//   * 0              -> ref-recovery ran but had nothing to surface
+// This distinction is the whole point of issue #3371 follow-up.
+function parseOptionalIntHeader(
+  headers: Record<string, string>,
+  name: string,
+): number | null {
+  const raw = headers[name];
+  if (raw === undefined || raw === null || raw === "") return null;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+function extractMCRFromBody(
+  body: Record<string, unknown>,
+): MCRMetadata | null {
+  const mcr = body.mcr as Record<string, unknown> | undefined;
+  if (!mcr || typeof mcr !== "object" || typeof mcr.session_fp !== "string")
+    return null;
+  return {
+    session_fp: mcr.session_fp as string,
+    stored_through:
+      typeof mcr.stored_through === "number" ? mcr.stored_through : 0,
+    safe_drop_before:
+      typeof mcr.safe_drop_before === "number" ? mcr.safe_drop_before : 0,
+  };
+}
+
+function extractEnergyFromBody(
+  body: Record<string, unknown>,
+): EnergyData | null {
+  const energy = body.energy as Record<string, unknown> | undefined;
+  if (!energy || typeof energy !== "object") return null;
+  const result: EnergyData = {
+    energy_joules:
+      typeof energy.energy_joules === "number" ? energy.energy_joules : 0,
+  };
+  if (energy.mcr && typeof energy.mcr === "object") {
+    const m = energy.mcr as Record<string, unknown>;
+    result.mcr = {
+      session_turns:
+        typeof m.session_turns === "number" ? m.session_turns : 0,
+      context_tokens:
+        typeof m.context_tokens === "number" ? m.context_tokens : 0,
+      compaction_triggered:
+        typeof m.compaction_triggered === "boolean"
+          ? m.compaction_triggered
+          : false,
+      apc_hit_rate:
+        typeof m.apc_hit_rate === "number" ? m.apc_hit_rate : undefined,
+      mcr_compacted_tokens:
+        typeof m.mcr_compacted_tokens === "number"
+          ? m.mcr_compacted_tokens
+          : undefined,
+      mcr_original_tokens:
+        typeof m.mcr_original_tokens === "number"
+          ? m.mcr_original_tokens
+          : undefined,
+    };
+  }
+  return result;
+}
+
+function formatEnergy(joules: number): string {
+  if (joules < 1) return `${(joules * 1000).toFixed(0)}mJ`;
+  if (joules < 1000) return `${joules.toFixed(1)}J`;
+  return `${(joules / 1000).toFixed(2)}kJ`;
+}
+
+// Extract the role/type marker from an entry. Pi's outbound HTTP payload
+// uses OpenAI-shape ``role`` (``user``/``assistant``/``tool``/``system``);
+// Pi's internal session-log records sometimes serialize the same field as
+// ``type``. Read both so this extension works regardless of which shape
+// the agent-runtime hands us via the ``context`` hook event.
+function entryRole(entry: { role?: string; type?: string }): string | undefined {
+  return entry.role ?? entry.type;
+}
+
+// Returns the FULL message index of the Nth user message (matching the
+// indexing space of the server's `safe_drop_before`, which counts every
+// message — user/assistant/tool/system — in send order). The earlier
+// version returned a user+assistant-subset index, which mixed index
+// spaces with `safe_drop_before` in `computeDropRange` and caused
+// `context_drop` to silently nuke the most-recent user prompts when the
+// upper bound exceeded the user+assistant subset size.
+function findAnchorFloor(
+  entries: Array<{ role?: string; type?: string }>,
+  nAnchors: number,
+): number {
+  let userCount = 0;
+  for (let i = 0; i < entries.length; i++) {
+    const role = entryRole(entries[i]);
+    if (role === "user") {
+      userCount++;
+      if (userCount === nAnchors) return i;
+    }
+  }
+  return -1;
+}
+
+// Server-side validation for X-NW-Conversation-ID (mirrors
+// services/mcr_v3_session.py::validate_client_conversation_id):
+//
+//   * non-empty, ≤ 256 chars
+//   * all code points printable (no control / whitespace beyond plain space)
+//
+// We sanitize here so a malformed Pi session id can never bounce off the
+// server as HTTP 400 — the worst case is we fall back to the in-process UUID.
+const MAX_CONVERSATION_ID_LEN = 256;
+
+function isWellFormedConversationId(value: string): boolean {
+  if (!value || value.length === 0 || value.length > MAX_CONVERSATION_ID_LEN) {
+    return false;
+  }
+  // Reject any control character (matches server's `not c.isprintable()` rule).
+  // We allow plain ASCII space (0x20) and everything ≥ 0x20 except 0x7F (DEL).
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code < 0x20 || code === 0x7f) return false;
+  }
+  return true;
+}
+
+// Per-process fallback id. Generated lazily so it stays stable across
+// auto-compact within one `pi` invocation, and differs across invocations.
+let uuidFallback: string | null = null;
+function getUuidFallback(): string {
+  if (!uuidFallback) {
+    uuidFallback = randomUUID();
+  }
+  return uuidFallback;
+}
+
+type ConversationIdSource = "pi-session" | "uuid-fallback";
+
+function resolveConversationId(
+  ctx: ExtensionContext,
+): { id: string; source: ConversationIdSource } {
+  // Preferred source: Pi's own session id. Stable across auto-compact in a
+  // single `pi` session, distinct across sessions, naturally string-form.
+  try {
+    const piSessionId = ctx.sessionManager?.getSessionId?.();
+    if (
+      typeof piSessionId === "string" &&
+      isWellFormedConversationId(piSessionId)
+    ) {
+      return { id: piSessionId, source: "pi-session" };
+    }
+  } catch {
+    // fall through to uuid fallback
+  }
+  return { id: getUuidFallback(), source: "uuid-fallback" };
+}
+
+function computeDropRange(
+  entries: Array<{ role?: string; type?: string }>,
+  safeDropBefore: number,
+): [number, number] {
+  if (safeDropBefore <= 0) return [0, 0];
+  const anchorIdx = findAnchorFloor(entries, MCR_ANCHOR_USER_MESSAGES);
+  if (anchorIdx < 0) return [0, 0];
+  const dropStart = anchorIdx + 1;
+  const dropEnd = safeDropBefore;
+  if (dropEnd <= dropStart) return [0, 0];
+  return [dropStart, dropEnd];
+}
+
+export default function (pi: ExtensionAPI) {
+  const MCR_STATUS_KEY = "nw-mcr";
+  const ENERGY_STATUS_KEY = "nw-energy";
+
+  // ── X-NW-Conversation-ID header wiring ──────────────────────────────
+  // pi-coding-agent's `before_provider_request` is a *body* hook — the
+  // earlier `payload.headers[...]` mutation reached extension memory only,
+  // never the HTTP wire. The documented per-request header path is
+  // `pi.registerProvider({ headers })`, whose values are env-var names that
+  // the SDK re-reads from `process.env` on every stream
+  // (dist/core/resolve-config-value.js). Net: real HTTP header, no body
+  // touch, no APC impact.
+  //
+  // Boot order: we seed the env var with a UUID at extension load so any
+  // request fired before the first `before_provider_request` tick still
+  // carries *some* id. The hook upgrades it to Pi's stable per-invocation
+  // session id (see resolveConversationId). Subsequent requests in the
+  // same `pi` invocation reuse the upgraded value — invocation-stable
+  // session_fp by construction.
+  const CONV_ID_ENV = "X_NW_CONVERSATION_ID";
+  if (!process.env[CONV_ID_ENV]) {
+    process.env[CONV_ID_ENV] = getUuidFallback();
+  }
+  // `apiKey` mirrors the env-var name from ~/.pi/agent/models.json so the
+  // partial config doesn't shadow the existing auth. `storeProviderRequestConfig`
+  // doesn't merge with the models.json-derived entry (different map), so we
+  // have to re-state any field we need; only apiKey here, since baseUrl/api
+  // flow through via the override-only branch of applyProviderConfig.
+  pi.registerProvider("neuralwatt", {
+    apiKey: "NEURALWATT_API_KEY",
+    headers: { "X-NW-Conversation-ID": CONV_ID_ENV },
+  });
+
+  function updateStatusBar(ctx: ExtensionContext) {
+    if (state.sessionFp) {
+      const parts: string[] = [`MCR ${state.sessionFp.slice(0, 8)}`];
+      if (state.safeDropBefore > 0) {
+        parts.push(`drop<${state.safeDropBefore}`);
+      }
+      ctx.ui.setStatus(MCR_STATUS_KEY, parts.join(" | "));
+    } else {
+      ctx.ui.setStatus(MCR_STATUS_KEY, "");
+    }
+
+    if (state.totalEnergyJoules > 0) {
+      const parts: string[] = [`⚡ ${formatEnergy(state.totalEnergyJoules)}`];
+      if (state.lastEnergy?.mcr) {
+        const m = state.lastEnergy.mcr;
+        if (m.apc_hit_rate !== undefined) {
+          parts.push(`APC ${(m.apc_hit_rate * 100).toFixed(0)}%`);
+        }
+        if (m.mcr_compacted_tokens && m.mcr_original_tokens) {
+          const ratio = m.mcr_compacted_tokens / m.mcr_original_tokens;
+          parts.push(`compact ${(ratio * 100).toFixed(0)}%`);
+        }
+      }
+      ctx.ui.setStatus(ENERGY_STATUS_KEY, parts.join(" | "));
+    } else {
+      ctx.ui.setStatus(ENERGY_STATUS_KEY, "");
+    }
+  }
+
+  // Upgrade X_NW_CONVERSATION_ID to Pi's stable session-id as early as
+  // possible — `session_start` fires before any provider request and is the
+  // earliest hook with ctx. Without this, the first request of each fresh
+  // `pi -p` invocation would carry the boot-time UUID (different per
+  // process) and produce a cold-cache session_fp that drags APC averages
+  // down on `--continue` chains.
+  pi.on("session_start", async (_event, ctx) => {
+    const { id: conversationId } = resolveConversationId(ctx);
+    process.env[CONV_ID_ENV] = conversationId;
+  });
+
+  pi.on("after_provider_response", async (event, ctx) => {
+    const modelId = ctx.model?.id || "";
+    if (!isMCRModel(modelId)) return;
+
+    const headers = event.headers as Record<string, string>;
+    const mcrFromHeaders = extractMCRFromHeaders(headers);
+
+    nwlog("after_provider_response", {
+      model: modelId,
+      header_fp: headers["x-mcr-session-fp"] ?? null,
+      header_safe_drop_before: headers["x-mcr-safe-drop-before"] ?? null,
+      header_stored_through: headers["x-mcr-stored-through"] ?? null,
+      parsed: mcrFromHeaders,
+    });
+
+    // M1.b ref-recovery observability (issue #3371 follow-up). The
+    // gateway's recent_ref_expansion path runs on the gateway->backend
+    // payload, which is invisible to Pi — without these headers in the
+    // log we can't tell "ref-recovery ran with no refs available" apart
+    // from "ref-recovery never ran". Counts only, no preview/sha values.
+    // Server-side emission: API_Gateway/app/services/mcr_anthropic_native_proxy.py::_add_mcr_refs_headers
+    const refsRecovered = parseOptionalIntHeader(headers, "x-mcr-refs-recovered");
+    const refsInForward = parseOptionalIntHeader(headers, "x-mcr-refs-in-forward");
+    const refsSkippedBudget = parseOptionalIntHeader(
+      headers,
+      "x-mcr-refs-skipped-budget",
+    );
+    const refsSkippedMissing = parseOptionalIntHeader(
+      headers,
+      "x-mcr-refs-skipped-missing",
+    );
+    const recoveryTokensAdded = parseOptionalIntHeader(
+      headers,
+      "x-mcr-recovery-tokens-added",
+    );
+    const manifestEntries = parseOptionalIntHeader(
+      headers,
+      "x-mcr-manifest-entries",
+    );
+
+    if (
+      refsRecovered !== null ||
+      refsInForward !== null ||
+      refsSkippedBudget !== null ||
+      refsSkippedMissing !== null ||
+      recoveryTokensAdded !== null ||
+      manifestEntries !== null
+    ) {
+      nwlog("mcr_refs", {
+        refs_recovered: refsRecovered,
+        refs_in_forward: refsInForward,
+        refs_skipped_budget: refsSkippedBudget,
+        refs_skipped_missing: refsSkippedMissing,
+        recovery_tokens_added: recoveryTokensAdded,
+        manifest_entries: manifestEntries,
+      });
+    }
+
+    if (mcrFromHeaders) {
+      state.sessionFp = mcrFromHeaders.session_fp;
+      state.safeDropBefore = mcrFromHeaders.safe_drop_before;
+      state.storedThrough = mcrFromHeaders.stored_through;
+      state.lastMcrMeta = mcrFromHeaders;
+    }
+
+    updateStatusBar(ctx);
+  });
+
+  pi.on("message_end", async (event, ctx) => {
+    if (event.message.role !== "assistant") return;
+    if (!isMCRModel(ctx.model?.id || "")) return;
+
+    const msg = event.message as Record<string, unknown>;
+
+    const mcrFromBody = extractMCRFromBody(msg);
+    if (mcrFromBody) {
+      nwlog("message_end_mcr_body", { parsed: mcrFromBody });
+      state.sessionFp = mcrFromBody.session_fp;
+      state.safeDropBefore = mcrFromBody.safe_drop_before;
+      state.storedThrough = mcrFromBody.stored_through;
+      state.lastMcrMeta = mcrFromBody;
+    }
+
+    const energy = extractEnergyFromBody(msg);
+    if (energy) {
+      nwlog("message_end_energy", {
+        energy_joules: energy.energy_joules,
+        cumulative_joules: state.totalEnergyJoules + energy.energy_joules,
+        session_turns: energy.mcr?.session_turns,
+        context_tokens: energy.mcr?.context_tokens,
+        compaction_triggered: energy.mcr?.compaction_triggered,
+        apc_hit_rate: energy.mcr?.apc_hit_rate,
+        mcr_compacted_tokens: energy.mcr?.mcr_compacted_tokens,
+        mcr_original_tokens: energy.mcr?.mcr_original_tokens,
+      });
+      state.totalEnergyJoules += energy.energy_joules;
+      state.lastEnergy = energy;
+      if (energy.mcr) {
+        state.sessionTurns = energy.mcr.session_turns;
+        state.contextTokens = energy.mcr.context_tokens;
+      }
+    }
+
+    updateStatusBar(ctx);
+  });
+
+  pi.on("context", async (event, ctx) => {
+    const modelId = ctx.model?.id || "";
+    const numMsgs = event.messages.length;
+
+    if (!state.sessionFp) {
+      nwlog("context_skip", {
+        reason: "no_session_fp",
+        model: modelId,
+        num_msgs: numMsgs,
+      });
+      return;
+    }
+    if (state.safeDropBefore <= 0) {
+      nwlog("context_skip", {
+        reason: "safe_drop_before_zero",
+        model: modelId,
+        num_msgs: numMsgs,
+        safe_drop_before: state.safeDropBefore,
+        session_fp: state.sessionFp,
+      });
+      return;
+    }
+    if (!isMCRModel(modelId)) {
+      nwlog("context_skip", {
+        reason: "not_mcr_model",
+        model: modelId,
+        num_msgs: numMsgs,
+      });
+      return;
+    }
+
+    const [dropStart, dropEnd] = computeDropRange(
+      event.messages as Array<{ type: string }>,
+      state.safeDropBefore,
+    );
+
+    if (dropEnd <= dropStart) {
+      nwlog("context_no_drop", {
+        reason: "empty_range",
+        drop_start: dropStart,
+        drop_end: dropEnd,
+        safe_drop_before: state.safeDropBefore,
+        num_msgs: numMsgs,
+        session_fp: state.sessionFp,
+      });
+      return;
+    }
+
+    // Drop messages in the full-index range [dropStart, dropEnd). Both
+    // bounds are in the same indexing space as `event.messages` and as the
+    // server's `safe_drop_before` (every message counted, all roles). The
+    // earlier version maintained a separate user+assistant-subset counter
+    // and compared it against full-index bounds, which silently nuked the
+    // most-recent user prompts (#bug discovered 2026-05-16 — see commit
+    // message for the trace).
+    const clampedEnd = Math.min(dropEnd, event.messages.length);
+    const filtered = event.messages.filter(
+      (_: unknown, i: number) => i < dropStart || i >= clampedEnd,
+    );
+    const droppedCount = numMsgs - filtered.length;
+
+    if (droppedCount === 0) {
+      nwlog("context_no_drop", {
+        reason: "no_indices_matched",
+        drop_start: dropStart,
+        drop_end: clampedEnd,
+        safe_drop_before: state.safeDropBefore,
+        num_msgs: numMsgs,
+        session_fp: state.sessionFp,
+      });
+      return;
+    }
+
+    nwlog("context_drop", {
+      drop_start: dropStart,
+      drop_end: clampedEnd,
+      safe_drop_before: state.safeDropBefore,
+      num_msgs_before: numMsgs,
+      num_msgs_after: filtered.length,
+      dropped: droppedCount,
+      session_fp: state.sessionFp,
+    });
+
+    return { messages: filtered };
+  });
+
+  pi.on("before_provider_request", async (event, ctx) => {
+    if (!isMCRModel(ctx.model?.id || "")) return;
+
+    const payload = event.payload as Record<string, unknown>;
+
+    // Upgrade the X_NW_CONVERSATION_ID env var (seeded with a UUID at
+    // extension load) to Pi's stable per-invocation session id. The SDK
+    // re-reads process.env on every stream, so this propagates to the
+    // next outbound request as the real X-NW-Conversation-ID HTTP header
+    // — no body touch. See the header-wiring block at the top of this fn
+    // and pi-header-surface.md for the full mechanism trace.
+    const { id: conversationId, source: conversationIdSource } =
+      resolveConversationId(ctx);
+    process.env[CONV_ID_ENV] = conversationId;
+    nwlog("conversation_id_attached", {
+      conversation_id_prefix: conversationId.slice(0, 8),
+      source: conversationIdSource,
+    });
+
+    // X-MCR-Session-FP fast-path hint: previously set via the same
+    // body-only mechanism that never reached the wire. Currently a no-op;
+    // diagnostic log retained so we still see when the gateway has
+    // assigned an fp. Revisit via registerProvider if we want it back.
+    if (state.sessionFp) {
+      nwlog("before_provider_request_fp_set", {
+        session_fp: state.sessionFp,
+        safe_drop_before: state.safeDropBefore,
+      });
+    }
+
+    // DEBUG (#3323 follow-up): capture the actual outbound payload shape
+    // so we can diagnose why the deployed pin-final-user-turn fix isn't
+    // firing for real Pi sessions. Logs shape only — no message content.
+    try {
+      const msgs = (payload.body as { messages?: Array<Record<string, unknown>> } | undefined)?.messages
+        ?? (payload.messages as Array<Record<string, unknown>> | undefined)
+        ?? [];
+      const roles = msgs.map((m) => String(m.role ?? m.type ?? "?"));
+      const lastN = msgs.slice(-5).map((m) => {
+        const role = String(m.role ?? m.type ?? "?");
+        const contentField = m.content;
+        let contentKind: string;
+        let contentLen: number;
+        if (typeof contentField === "string") {
+          contentKind = "string";
+          contentLen = contentField.length;
+        } else if (Array.isArray(contentField)) {
+          contentKind = "array[" + contentField.length + "]";
+          contentLen = contentField.reduce((acc, b) => acc + JSON.stringify(b).length, 0);
+        } else if (contentField === null || contentField === undefined) {
+          contentKind = "null";
+          contentLen = 0;
+        } else {
+          contentKind = typeof contentField;
+          contentLen = JSON.stringify(contentField).length;
+        }
+        const blockTypes = Array.isArray(contentField)
+          ? (contentField as Array<Record<string, unknown>>).map((b) => String(b.type ?? "?"))
+          : null;
+        return { role, contentKind, contentLen, blockTypes, hasToolCallId: "tool_call_id" in m };
+      });
+      const roleCounts: Record<string, number> = {};
+      for (const r of roles) roleCounts[r] = (roleCounts[r] || 0) + 1;
+      nwlog("outbound_payload_shape", {
+        session_fp: state.sessionFp,
+        num_messages: msgs.length,
+        role_distribution: roleCounts,
+        last_5_messages: lastN,
+        stream: Boolean((payload.body as { stream?: boolean } | undefined)?.stream ?? payload.stream),
+        payload_keys: Object.keys(payload),
+      });
+    } catch (err) {
+      nwlog("outbound_payload_shape_error", {
+        session_fp: state.sessionFp,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  });
+
+  pi.on("session_before_compact", async (_event, ctx) => {
+    if (!isMCRModel(ctx.model?.id || "")) return;
+    if (state.sessionFp) {
+      nwlog("compaction_cancelled", { session_fp: state.sessionFp });
+      return { cancel: true };
+    }
+  });
+
+  pi.on("session_start", async (_event, ctx) => {
+    nwlog("session_start", {});
+    state.sessionFp = null;
+    state.safeDropBefore = 0;
+    state.storedThrough = 0;
+    state.totalEnergyJoules = 0;
+    state.sessionTurns = 0;
+    state.contextTokens = 0;
+    state.lastMcrMeta = null;
+    state.lastEnergy = null;
+    // Reset the UUID fallback so a new Pi session gets a fresh conversation
+    // id when getSessionId() isn't usable. The Pi session id itself rotates
+    // on its own.
+    uuidFallback = null;
+    ctx.ui.setStatus(MCR_STATUS_KEY, "");
+    ctx.ui.setStatus(ENERGY_STATUS_KEY, "");
+  });
+
+  pi.on("session_shutdown", async (_event, ctx) => {
+    nwlog("session_shutdown", {
+      final_session_fp: state.sessionFp,
+      total_energy_joules: state.totalEnergyJoules,
+      session_turns: state.sessionTurns,
+    });
+    ctx.ui.setStatus(MCR_STATUS_KEY, "");
+    ctx.ui.setStatus(ENERGY_STATUS_KEY, "");
+  });
+}


### PR DESCRIPTION
## Summary

Follow-up to #23. A customer reported that having an existing `neuralwatt` provider already configured in Pi (via `pi /provider`, a prior `models.json`, or another extension) can take precedence over the bundled `models.json` from this plugin — the long-context aliases may not appear in `/model` or may not route. Add a callout next to the copy step in `plugins/pi/README.md`.

## Test plan
- [x] Wording is concrete (names the symptom + the two places to check + how to fix)
- [x] No code changes