### PR TITLE
chore(pi): drop retired/private aliases from models.json

### DIFF
--- a/plugins/pi/configs/models.json
+++ b/plugins/pi/configs/models.json
@@ -59,41 +59,9 @@
           }
         },
         {
-          "id": "neuralwatt/glm-5-long",
-          "name": "GLM-5 Long (MCR 1M)",
-          "reasoning": true,
-          "input": [
-            "text"
-          ],
-          "contextWindow": 1048576,
-          "maxTokens": 16384,
-          "cost": {
-            "input": 0,
-            "output": 0,
-            "cacheRead": 0,
-            "cacheWrite": 0
-          }
-        },
-        {
           "id": "neuralwatt/glm-5.1-long",
           "name": "GLM-5.1 Long (MCR 1M)",
           "reasoning": true,
-          "input": [
-            "text"
-          ],
-          "contextWindow": 1048576,
-          "maxTokens": 16384,
-          "cost": {
-            "input": 0,
-            "output": 0,
-            "cacheRead": 0,
-            "cacheWrite": 0
-          }
-        },
-        {
-          "id": "neuralwatt/glm-5.1-fast-long",
-          "name": "GLM-5.1 Fast Long (MCR 1M)",
-          "reasoning": false,
           "input": [
             "text"
           ],
@@ -192,23 +160,6 @@
           }
         },
         {
-          "id": "neuralwatt/kimi-k2.5-long",
-          "name": "Kimi K2.5 Long (MCR 1M)",
-          "reasoning": true,
-          "input": [
-            "text",
-            "image"
-          ],
-          "contextWindow": 1048576,
-          "maxTokens": 16384,
-          "cost": {
-            "input": 0,
-            "output": 0,
-            "cacheRead": 0,
-            "cacheWrite": 0
-          }
-        },
-        {
           "id": "Qwen/Qwen3.6-35B-A3B",
           "name": "Qwen3.6 35B",
           "reasoning": true,
@@ -226,42 +177,9 @@
           }
         },
         {
-          "id": "qwen3.6-35b-fast",
-          "name": "Qwen3.6 35B Fast",
-          "reasoning": false,
-          "input": [
-            "text",
-            "image"
-          ],
-          "contextWindow": 131072,
-          "maxTokens": 8192,
-          "cost": {
-            "input": 0,
-            "output": 0,
-            "cacheRead": 0,
-            "cacheWrite": 0
-          }
-        },
-        {
           "id": "Qwen/Qwen3.5-397B-A17B-FP8",
           "name": "Qwen3.5 397B FP8",
           "reasoning": true,
-          "input": [
-            "text"
-          ],
-          "contextWindow": 262144,
-          "maxTokens": 8192,
-          "cost": {
-            "input": 0,
-            "output": 0,
-            "cacheRead": 0,
-            "cacheWrite": 0
-          }
-        },
-        {
-          "id": "qwen3.5-397b-fast",
-          "name": "Qwen3.5 397B Fast",
-          "reasoning": false,
           "input": [
             "text"
           ],
@@ -316,22 +234,6 @@
           ],
           "contextWindow": 16384,
           "maxTokens": 8192,
-          "cost": {
-            "input": 0,
-            "output": 0,
-            "cacheRead": 0,
-            "cacheWrite": 0
-          }
-        },
-        {
-          "id": "neuralwatt/claude-opus-cached",
-          "name": "Claude Opus (Cached)",
-          "reasoning": true,
-          "input": [
-            "text"
-          ],
-          "contextWindow": 1000000,
-          "maxTokens": 32000,
           "cost": {
             "input": 0,
             "output": 0,


### PR DESCRIPTION
## Summary

Removes 6 model IDs from `plugins/pi/configs/models.json` that should never have been shown in Pi's `/model` picker for end users — they're either retired aliases, internal/private aliases without a grants pathway, or non-routable drafts. Today they cause real 404 support tickets: a user picks one (e.g. `neuralwatt/kimi-k2.5-long`) and gets `ACCESS_DENIED` even though their MCR grant covers the canonical `kimi-k2.6-long`.

Dropped:

| Alias | Why |
|-------|-----|
| `neuralwatt/glm-5-long` | retired, not routable |
| `neuralwatt/glm-5.1-fast-long` | retired |
| `neuralwatt/kimi-k2.5-long` | retired; canonical replacement is `neuralwatt/kimi-k2.6-long` |
| `qwen3.6-35b-fast` | not routable in current production catalog |
| `qwen3.5-397b-fast` | not routable in current production catalog |
| `neuralwatt/claude-opus-cached` | private/internal alias, zero customer grants exist |

Kept (still routable & catalogued): `glm-5.1-fast`, `glm-5-fast`, `kimi-k2.6-fast`, `kimi-k2.5-fast`, the canonical MCR long aliases `neuralwatt/glm-5.1-long` and `neuralwatt/kimi-k2.6-long`, the direct parent model IDs, and the third-party catalog (`Qwen/*`, `mistralai/*`, `openai/*`, `MiniMaxAI/*`).

## Test plan

- [x] JSON still parses (`python3 -c 'import json; json.load(open(...))'`)
- [x] Diff is pure deletions — no formatting drift
- [ ] Manually launch Pi with the updated config and confirm `/model` no longer shows the dropped entries
- [ ] Existing MCR users continue to land on `neuralwatt/kimi-k2.6-long` and `neuralwatt/glm-5.1-long` without regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)