### PR TITLE
feat(pi-ext): render compaction status from gateway mcr-status events (#3914)

### DIFF
--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -75,14 +75,22 @@ When you're on an MCR model, two indicators appear in Pi's footer:
 
 | Key | Shows |
 |-----|-------|
-| `nw-mcr` | Session fingerprint (first 8 chars) + current drop threshold |
+| `nw-mcr` | Session fingerprint (first 8 chars) + current drop threshold. While a request is in flight, switches to `optimizing context… 1.4s` so multi-second compaction pauses don't look like a hung model. |
 | `nw-energy` | Cumulative energy (mJ/J/kJ), APC cache hit rate, compaction ratio |
 
-Example:
+Example (idle):
 
 ```
 MCR a1b2c3d4 | drop<35    nw-energy 2.3J | APC 85% | compact 42%
 ```
+
+Example (request in flight, server compacting or warming the prefix cache):
+
+```
+MCR a1b2c3d4 | optimizing context… 1.4s
+```
+
+The elapsed counter advances every ~0.5s until the model starts streaming real output, at which point the chip reverts to the standard view. This addresses the perception that long MCR requests have hung — see [`neuralwatt/inference_frontend#3914`](https://github.com/neuralwatt/inference_frontend/issues/3914) for the customer feedback that prompted the change.
 
 ## How context drop works
 
@@ -126,12 +134,15 @@ For non-MCR models the extension stays out of the way — Pi behaves exactly as 
 Pi extension (neuralwatt-mcr.ts)
   |
   +- after_provider_response   reads X-MCR-* headers
-  +- message_end               reads response body mcr/energy (fallback)
+  +- message_update            clears in-flight chip on first model delta (#3914)
+  +- message_end               reads response body mcr/energy (fallback);
+                                 backstop for clearing in-flight chip
   +- context                   drops messages per safe_drop_before
-  +- before_provider_request   sends X-MCR-Session-FP header
+  +- before_provider_request   sends X-MCR-Session-FP header;
+                                 starts in-flight chip (#3914)
   +- session_before_compact    cancels Pi compaction when MCR active
-  +- session_start             resets state
-  +- session_shutdown          clears status bar
+  +- session_start             resets state (incl. in-flight chip)
+  +- session_shutdown          clears status bar (incl. in-flight ticker)
 ```
 
 ## Feedback

--- a/plugins/pi/extensions/neuralwatt-mcr.ts
+++ b/plugins/pi/extensions/neuralwatt-mcr.ts
@@ -51,6 +51,12 @@ interface SessionState {
   contextTokens: number;
   lastMcrMeta: MCRMetadata | null;
   lastEnergy: EnergyData | null;
+  // Issue #3914: in-flight request UX. When an MCR request is sent we flip
+  // ``inFlightSince`` to the wall-clock send time so the chip can show
+  // "optimizing context…" until the response stream produces real model
+  // output. Cleared on first ``message_update`` or on ``message_end``.
+  inFlightSince: number | null;
+  inFlightTickerHandle: NodeJS.Timeout | null;
 }
 
 const state: SessionState = {
@@ -62,7 +68,14 @@ const state: SessionState = {
   contextTokens: 0,
   lastMcrMeta: null,
   lastEnergy: null,
+  inFlightSince: null,
+  inFlightTickerHandle: null,
 };
+
+// Issue #3914: how often to refresh the chip while the in-flight indicator
+// is showing, so the elapsed counter advances visibly. 500ms is fast enough
+// to feel live but well below the refresh budget of Pi's footer.
+const IN_FLIGHT_TICK_MS = 500;
 
 function isMCRModel(modelId: string): boolean {
   return (
@@ -160,6 +173,17 @@ function formatEnergy(joules: number): string {
   if (joules < 1) return `${(joules * 1000).toFixed(0)}mJ`;
   if (joules < 1000) return `${joules.toFixed(1)}J`;
   return `${(joules / 1000).toFixed(2)}kJ`;
+}
+
+// Issue #3914: render an in-flight elapsed-time stamp for the chip. Short
+// formats (<10s → "1.4s", >=10s → "12s", >=60s → "1m 5s") to keep the chip
+// from growing wide enough to push other footer widgets off-screen.
+function formatElapsed(ms: number): string {
+  if (ms < 10000) return `${(ms / 1000).toFixed(1)}s`;
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}m ${seconds % 60}s`;
 }
 
 // Extract the role/type marker from an entry. Pi's outbound HTTP payload
@@ -294,7 +318,25 @@ export default function (pi: ExtensionAPI) {
   });
 
   function updateStatusBar(ctx: ExtensionContext) {
-    if (state.sessionFp) {
+    // Issue #3914: when an MCR request is in flight, show an "optimizing
+    // context…" indicator with elapsed time so the user knows the gateway
+    // is working (compaction or KV pre-warm) and the model hasn't hung.
+    // Dio's first-MCR-tester feedback (2026-05-28) named the exact failure
+    // mode this fixes: a silent multi-second pause looking identical to a
+    // crashed model. The in-flight indicator takes precedence over the
+    // standard "MCR <fp> | drop<N>" chip text — once the response stream
+    // produces real model output, ``markStreamProducing`` clears
+    // ``inFlightSince`` and the chip reverts to the standard view.
+    if (state.inFlightSince !== null) {
+      const elapsedMs = Date.now() - state.inFlightSince;
+      const fpPrefix = state.sessionFp
+        ? `MCR ${state.sessionFp.slice(0, 8)} | `
+        : "MCR | ";
+      ctx.ui.setStatus(
+        MCR_STATUS_KEY,
+        `${fpPrefix}optimizing context… ${formatElapsed(elapsedMs)}`,
+      );
+    } else if (state.sessionFp) {
       const parts: string[] = [`MCR ${state.sessionFp.slice(0, 8)}`];
       if (state.safeDropBefore > 0) {
         parts.push(`drop<${state.safeDropBefore}`);
@@ -320,6 +362,53 @@ export default function (pi: ExtensionAPI) {
     } else {
       ctx.ui.setStatus(ENERGY_STATUS_KEY, "");
     }
+  }
+
+  // Issue #3914: lifecycle helpers for the in-flight indicator. We bracket
+  // the wait window with ``markRequestSent`` (on before_provider_request)
+  // and ``markStreamProducing`` (on the first message_update / message_end
+  // that carries real model output).
+  //
+  // The chip's elapsed counter advances via a ``setInterval`` that re-calls
+  // ``updateStatusBar`` every ~0.5s. Without the ticker the chip would
+  // freeze at "0.0s" until the response arrives, defeating the point.
+  //
+  // Forward-compatible note: the gateway (issue #3914 server side) also
+  // emits ``event: mcr-status`` SSE frames carrying {phase: compacting |
+  // warming | idle, elapsed_ms}. Pi's extension API does not currently
+  // surface raw SSE event types other than the standard message deltas
+  // (see types.d.ts::AssistantMessageEvent — only text/thinking/toolcall
+  // types reach extensions). When Pi adds an SSE-event hook we can swap
+  // the time-based estimate below for the server's authoritative phase
+  // signal and distinguish "compacting" from "warming" in the chip text.
+  function markRequestSent(ctx: ExtensionContext) {
+    state.inFlightSince = Date.now();
+    if (state.inFlightTickerHandle !== null) {
+      clearInterval(state.inFlightTickerHandle);
+    }
+    state.inFlightTickerHandle = setInterval(() => {
+      // Defensive: stop ticking if the in-flight flag was cleared
+      // out-of-band (e.g. session_start reset).
+      if (state.inFlightSince === null) {
+        if (state.inFlightTickerHandle !== null) {
+          clearInterval(state.inFlightTickerHandle);
+          state.inFlightTickerHandle = null;
+        }
+        return;
+      }
+      updateStatusBar(ctx);
+    }, IN_FLIGHT_TICK_MS);
+    updateStatusBar(ctx);
+  }
+
+  function markStreamProducing(ctx: ExtensionContext) {
+    if (state.inFlightSince === null) return;
+    state.inFlightSince = null;
+    if (state.inFlightTickerHandle !== null) {
+      clearInterval(state.inFlightTickerHandle);
+      state.inFlightTickerHandle = null;
+    }
+    updateStatusBar(ctx);
   }
 
   // Upgrade X_NW_CONVERSATION_ID to Pi's stable session-id as early as
@@ -401,9 +490,26 @@ export default function (pi: ExtensionAPI) {
     updateStatusBar(ctx);
   });
 
+  // Issue #3914: clear the in-flight indicator on the first message_update
+  // for an MCR model — at that point real model tokens are flowing, the
+  // "is it hung?" perception is gone, and the chip should revert to the
+  // standard MCR-fingerprint view. The MessageUpdateEvent fires for any
+  // assistant streaming update (text/thinking/toolcall deltas); we don't
+  // need to narrow further since any of these prove the wait is over.
+  pi.on("message_update", async (event, ctx) => {
+    if (event.message.role !== "assistant") return;
+    if (!isMCRModel(ctx.model?.id || "")) return;
+    markStreamProducing(ctx);
+  });
+
   pi.on("message_end", async (event, ctx) => {
     if (event.message.role !== "assistant") return;
     if (!isMCRModel(ctx.model?.id || "")) return;
+
+    // Issue #3914: backstop — if a response was short enough that no
+    // message_update ever fired, message_end is the latest possible
+    // chance to clear the indicator before it gets stale.
+    markStreamProducing(ctx);
 
     const msg = event.message as Record<string, unknown>;
 
@@ -530,6 +636,14 @@ export default function (pi: ExtensionAPI) {
 
     const payload = event.payload as Record<string, unknown>;
 
+    // Issue #3914: start the in-flight indicator. The chip shows
+    // "optimizing context… 1.4s" with the elapsed counter advancing every
+    // ~0.5s until the model starts producing real output (handled in
+    // ``message_update``). For MCR-long requests this window can be
+    // multiple seconds (compaction + KV pre-warm + TTFT); without the
+    // indicator the chat UI is indistinguishable from a hung model.
+    markRequestSent(ctx);
+
     // Upgrade the X_NW_CONVERSATION_ID env var (seeded with a UUID at
     // extension load) to Pi's stable per-invocation session id. The SDK
     // re-reads process.env on every stream, so this propagates to the
@@ -622,6 +736,15 @@ export default function (pi: ExtensionAPI) {
     state.contextTokens = 0;
     state.lastMcrMeta = null;
     state.lastEnergy = null;
+    // Issue #3914: clear any in-flight indicator left over from a prior
+    // session (defensive — session_start would normally fire after any
+    // active request has completed, but a forced restart or fork can land
+    // here while inFlightSince is still set).
+    state.inFlightSince = null;
+    if (state.inFlightTickerHandle !== null) {
+      clearInterval(state.inFlightTickerHandle);
+      state.inFlightTickerHandle = null;
+    }
     // Reset the UUID fallback so a new Pi session gets a fresh conversation
     // id when getSessionId() isn't usable. The Pi session id itself rotates
     // on its own.
@@ -636,6 +759,13 @@ export default function (pi: ExtensionAPI) {
       total_energy_joules: state.totalEnergyJoules,
       session_turns: state.sessionTurns,
     });
+    // Issue #3914: tear down the in-flight ticker so the interval handle
+    // doesn't outlive the session.
+    state.inFlightSince = null;
+    if (state.inFlightTickerHandle !== null) {
+      clearInterval(state.inFlightTickerHandle);
+      state.inFlightTickerHandle = null;
+    }
     ctx.ui.setStatus(MCR_STATUS_KEY, "");
     ctx.ui.setStatus(ENERGY_STATUS_KEY, "");
   });


### PR DESCRIPTION
## Summary

When MCR runs background compaction or KV pre-warming, the wait between request send and the first model token can stretch several seconds. Without an in-band indicator, the chat UI looks indistinguishable from a hung model. This PR makes the existing ``nw-mcr`` chip switch to ``MCR a1b2c3d4 | optimizing context… 1.4s`` while a request is in flight, then revert to the normal session-fingerprint view once tokens start flowing.

Companion to the gateway PR [neuralwatt/inference_frontend#3916](https://github.com/neuralwatt/inference_frontend/pull/3916), which emits ``event: mcr-status`` SSE frames carrying the actual phase (``compacting`` / ``warming``) and elapsed time on the wire. Pi's extension API does not currently surface raw SSE event types other than the standard message deltas (text/thinking/toolcall — see ``types.d.ts::AssistantMessageEvent``), so this PR uses the ``before_provider_request`` → ``message_update`` window as a time-based proxy. A docstring on ``markRequestSent`` documents the upgrade path: when Pi adds an SSE-event hook, swap the proxy for the gateway's authoritative phase signal and distinguish ``compacting`` from ``warming`` in the chip text.

## Lifecycle wiring

* ``before_provider_request`` → ``markRequestSent`` → start chip ticker
* ``message_update`` → ``markStreamProducing`` → clear ticker (primary signal)
* ``message_end`` → ``markStreamProducing`` → clear ticker (backstop for very-short responses)
* ``session_start`` / ``session_shutdown`` → teardown ticker (defensive)

The chip's elapsed counter refreshes every ~0.5s via ``setInterval``; the interval handle is tracked in ``SessionState`` and cleared whenever the in-flight state ends, so there's no leak across requests or sessions.

## Test plan

No unit tests in this repo today, so verification is manual:

- [ ] Hit ``neuralwatt/glm-5.1-long`` with a long prompt that triggers compaction; observe the chip flip to ``optimizing context… <elapsed>`` during TTFT and revert to ``MCR <fp> | drop<N>`` once tokens flow
- [ ] Hit a non-MCR model (e.g. ``glm-5-fast``) and confirm the chip stays empty (no regression on the standard Pi UX for non-MCR models)
- [ ] Forcibly exit during an in-flight request (Ctrl+C, ``/exit``, or kill the process) and confirm the ticker doesn't leak — session_shutdown clears it
- [ ] Confirm ``/model`` switching mid-session doesn't strand the chip in the in-flight state

## Why this is safe to ship independently

* Time-based proxy works even without the gateway PR merged — no protocol dependency
* Non-MCR models are gated out (``isMCRModel`` check on every relevant hook) — zero behaviour change for them
* The existing ``nw-mcr`` chip rendering when no phase is active is unchanged

Closes [neuralwatt/inference_frontend#3914](https://github.com/neuralwatt/inference_frontend/issues/3914) (client side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)