### PR TITLE
feat(pi): add session_tree handler for MCR state reset on branch navigation

### DIFF
--- a/plugins/pi/extensions/neuralwatt-mcr.ts
+++ b/plugins/pi/extensions/neuralwatt-mcr.ts
@@ -430,6 +430,7 @@ export default function (pi: ExtensionAPI) {
       });
       state.totalEnergyJoules += energy.energy_joules;
       state.lastEnergy = energy;
+      pi.appendEntry("neuralwatt-energy", { energy_joules: energy.energy_joules });
       if (energy.mcr) {
         state.sessionTurns = energy.mcr.session_turns;
         state.contextTokens = energy.mcr.context_tokens;
@@ -628,6 +629,37 @@ export default function (pi: ExtensionAPI) {
     uuidFallback = null;
     ctx.ui.setStatus(MCR_STATUS_KEY, "");
     ctx.ui.setStatus(ENERGY_STATUS_KEY, "");
+  });
+
+  pi.on("session_tree", async (_event, ctx) => {
+    // Branch navigation invalidates MCR session state — sessionFp and
+    // safeDropBefore are tied to a specific message sequence that no
+    // longer matches the new branch. Clear everything and let the
+    // next server response repopulate. Energy is replayed from the
+    // session log (same as the main provider's session_tree handler).
+    state.sessionFp = null;
+    state.safeDropBefore = 0;
+    state.storedThrough = 0;
+    state.totalEnergyJoules = 0;
+    state.sessionTurns = 0;
+    state.contextTokens = 0;
+    state.lastMcrMeta = null;
+    state.lastEnergy = null;
+
+    // Replay energy events from the session log for the new branch.
+    for (const entry of ctx.sessionManager.getBranch()) {
+      if (
+        entry.type === "custom" &&
+        entry.customType === "neuralwatt-energy" &&
+        typeof entry.data === "object" &&
+        entry.data
+      ) {
+        state.totalEnergyJoules += (entry.data as { energy_joules: number }).energy_joules || 0;
+      }
+    }
+
+    nwlog("session_tree", { total_energy_replayed: state.totalEnergyJoules });
+    updateStatusBar(ctx);
   });
 
   pi.on("session_shutdown", async (_event, ctx) => {


### PR DESCRIPTION
## Summary

The `neuralwatt-mcr` pi extension was missing a `session_tree` event handler. When a user navigates branches via `/tree`, MCR session state (`sessionFp`, `safeDropBefore`, etc.) becomes stale because it is tied to a specific message sequence that no longer matches the new branch. This caused incorrect context-dropping requests and a wrong status bar display after branch switches.

## Changes

### `plugins/pi/extensions/neuralwatt-mcr.ts`

- **Add `session_tree` event handler** — resets all MCR state fields on branch navigation (same resets as `session_start`, minus `uuidFallback` which must stay stable within the same Pi session). After clearing state, replays energy events from the new branch's session log so `totalEnergyJoules` stays accurate, then refreshes the status bar.

- **Persist energy events to session log** — added `pi.appendEntry("neuralwatt-energy", { energy_joules: ... })` in the `message_end` handler so the `session_tree` replay loop has entries to scan.

## Testing

- Manually tested branch navigation (`/tree`) with an active MCR session:
  - Status bar clears stale MCR fingerprint and drop-window display ✓
  - Energy counter correctly replays from the new branch ✓
  - Next provider response repopulates `sessionFp` and `safeDropBefore` as expected ✓