### PR TITLE
docs(plugins/pi): warn that an existing neuralwatt provider can shadow the bundled model list

### DIFF
--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -47,6 +47,8 @@ cp neuralwatt-tools/plugins/pi/configs/models.json ~/.pi/agent/models.json
 
 If you already have a `~/.pi/agent/models.json` with other providers, merge the `neuralwatt` provider entry into your existing file instead of overwriting.
 
+> ⚠️ **Heads up: an existing `neuralwatt` provider can shadow the bundled model list.** If you've previously added a Neuralwatt provider to Pi (via `pi /provider`, a prior `models.json`, or another extension), it can take precedence and the long-context aliases below may not appear in `/model` or may not route correctly. Before copying, check `pi /provider` and `~/.pi/agent/models.json` for an existing `neuralwatt` entry — remove it (or merge the bundled `models` array into it) so the canonical list from this repo is what Pi sees.
+
 ### 4. Copy the extension
 
 Pi auto-discovers extensions under `~/.pi/agent/extensions/`:


### PR DESCRIPTION
## Summary

A customer reported that a pre-existing `neuralwatt` provider in Pi (via `pi /provider`, a prior `models.json`, or another extension) can take precedence over the bundled `models.json`, so the long-context aliases don't appear in `/model` or don't route. Adds a callout next to the copy step in `plugins/pi/README.md`.

## Context

Replaces the stale **#24**, whose branch (`feat/add-pi-mcr-extension`) was the original extension PR #23's branch — it re-added the already-merged extension (+1131) and conflicted with #25. This is just the net-new 2-line callout off current `main`.

## Test plan
- [x] Wording names the symptom + the two places to check + how to fix
- [x] No code changes (docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)