### PR TITLE
fix(pi-ext): use explicit $ prefix for provider env var references

### DIFF
--- a/plugins/pi/extensions/neuralwatt-mcr.ts
+++ b/plugins/pi/extensions/neuralwatt-mcr.ts
@@ -313,8 +313,8 @@ export default function (pi: ExtensionAPI) {
   // have to re-state any field we need; only apiKey here, since baseUrl/api
   // flow through via the override-only branch of applyProviderConfig.
   pi.registerProvider("neuralwatt", {
-    apiKey: "NEURALWATT_API_KEY",
-    headers: { "X-NW-Conversation-ID": CONV_ID_ENV },
+    apiKey: "$NEURALWATT_API_KEY",
+    headers: { "X-NW-Conversation-ID": "$X_NW_CONVERSATION_ID" },
   });
 
   function updateStatusBar(ctx: ExtensionContext) {


### PR DESCRIPTION
## Summary

Pi now requires the `$` prefix to disambiguate environment variable references from literal string values in `registerProvider()`. The bare-name form is deprecated and will stop resolving in a future release.

## Changes

- `apiKey`: `"NEURALWATT_API_KEY"` → `"$NEURALWATT_API_KEY"`
- `headers` `"X-NW-Conversation-ID"`: `CONV_ID_ENV` → `"$X_NW_CONVERSATION_ID"`

## Deprecation warnings resolved

```
Deprecation warning: registerProvider("neuralwatt") apiKey value "NEURALWATT_API_KEY" is treated as a legacy environment variable reference. This will no longer be detected as an environment variable reference in a future release. Pass "$NEURALWATT_API_KEY" instead.
Deprecation warning: registerProvider("neuralwatt") headers header "X-NW-Conversation-ID" value "X_NW_CONVERSATION_ID" is treated as a legacy environment variable reference. This will no longer be detected as an environment variable reference in a future release. Pass "$X_NW_CONVERSATION_ID" instead.
```