### PR TITLE
fix(pi-ext): use $-prefixed env-var refs in registerProvider (deprecation warning)

### DIFF
--- a/plugins/pi/extensions/neuralwatt-mcr.ts
+++ b/plugins/pi/extensions/neuralwatt-mcr.ts
@@ -312,9 +312,16 @@ export default function (pi: ExtensionAPI) {
   // doesn't merge with the models.json-derived entry (different map), so we
   // have to re-state any field we need; only apiKey here, since baseUrl/api
   // flow through via the override-only branch of applyProviderConfig.
+  //
+  // Env-var references use the explicit `$NAME` form. Pi deprecated the
+  // bare-name auto-detection ("NEURALWATT_API_KEY") — it now warns and will
+  // stop resolving bare names in a future release, so we pass `$`-prefixed
+  // values. `CONV_ID_ENV` itself stays bare because it's also used for
+  // `process.env[CONV_ID_ENV]` access above; only the registerProvider value
+  // gets the `$` prefix.
   pi.registerProvider("neuralwatt", {
-    apiKey: "NEURALWATT_API_KEY",
-    headers: { "X-NW-Conversation-ID": CONV_ID_ENV },
+    apiKey: "$NEURALWATT_API_KEY",
+    headers: { "X-NW-Conversation-ID": `$${CONV_ID_ENV}` },
   });
 
   function updateStatusBar(ctx: ExtensionContext) {


### PR DESCRIPTION
## Summary

Users reported a deprecation warning in the Pi console from the `neuralwatt-mcr` extension:

> Deprecation warning: `registerProvider("neuralwatt")` apiKey value "NEURALWATT_API_KEY" is treated as a legacy environment variable reference. This will no longer be detected as an environment variable reference in a future release. Pass "\$NEURALWATT_API_KEY" instead.
>
> Deprecation warning: `registerProvider("neuralwatt")` headers header "X-NW-Conversation-ID" value "X_NW_CONVERSATION_ID" is treated as a legacy environment variable reference ... Pass "\$X_NW_CONVERSATION_ID" instead.

Pi deprecated bare-name env-var auto-detection in `registerProvider` config. The extension passed bare names (`apiKey: "NEURALWATT_API_KEY"`, `headers: { "X-NW-Conversation-ID": CONV_ID_ENV }`), which Pi still resolves but now warns about — and it will stop resolving them in a future release.

## Change

`plugins/pi/extensions/neuralwatt-mcr.ts` — switch both `registerProvider` values to the explicit `$`-prefixed form:
- `apiKey: "NEURALWATT_API_KEY"` → `apiKey: "$NEURALWATT_API_KEY"`
- `headers: { "X-NW-Conversation-ID": CONV_ID_ENV }` → `{ "X-NW-Conversation-ID": \`$${CONV_ID_ENV}\` }`

`CONV_ID_ENV` (= `"X_NW_CONVERSATION_ID"`) stays bare because it's also used for `process.env[CONV_ID_ENV]` read/write; only the `registerProvider` value gets the `$` prefix.

## Test plan
- [x] Bare names replaced with `$`-prefixed form at both sites
- [x] `CONV_ID_ENV` left bare for `process.env` access (unchanged behavior)
- [ ] After updating the extension, no deprecation warnings in the Pi console; auth + X-NW-Conversation-ID header still resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)