### PR TITLE
fix(pi-ext): make optimizing-context chip honest — only show during real MCR work (#33)

### DIFF
--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -77,22 +77,78 @@ When you're on an MCR model, two indicators appear in Pi's footer:
 
 | Key | Shows |
 |-----|-------|
-| `nw-mcr` | Session fingerprint (first 8 chars) + current drop threshold. While a request is in flight, switches to `optimizing context… 1.4s` so multi-second compaction pauses don't look like a hung model. |
+| `nw-mcr` | Session fingerprint (first 8 chars) + current drop threshold. If a request runs unusually long (more than a few seconds), it switches to a neutral `working… 12s` so a long wait doesn't look like a hung model. |
 | `nw-energy` | Cumulative energy (mJ/J/kJ), APC cache hit rate, compaction ratio |
 
-Example (idle):
+Example (idle, or during a normal request):
 
 ```
 MCR a1b2c3d4 | drop<35    nw-energy 2.3J | APC 85% | compact 42%
 ```
 
-Example (request in flight, server compacting or warming the prefix cache):
+Example (request still running after several seconds):
 
 ```
-MCR a1b2c3d4 | optimizing context… 1.4s
+MCR a1b2c3d4 | working… 12s
 ```
 
-The elapsed counter advances every ~0.5s until the model starts streaming real output, at which point the chip reverts to the standard view. This addresses the perception that long MCR requests have hung — see [`neuralwatt/inference_frontend#3914`](https://github.com/neuralwatt/inference_frontend/issues/3914) for the customer feedback that prompted the change.
+### Why "working…" and not "optimizing context…"
+
+Earlier versions showed `optimizing context… Ns` for the **entire** time between
+sending a request and the first model token, on **every** MCR request. Because
+MCR prompts are large (100k+ tokens), that prefill window is naturally 10–60s —
+so users saw "optimizing context" on nearly every prompt, for the whole wait,
+even though actual context compaction happens on only a small fraction of turns.
+That made MCR feel like it was making every prompt slow, which it wasn't.
+
+The honest fix:
+
+- **Normal turns are silent.** Nothing changes in the chip for the first few
+  seconds — the passive `MCR <fp> | drop<N>` status stays put.
+- **Long waits get a neutral label.** Only after a grace window does the chip
+  surface `working… Ns` — a truthful "a request is in flight" signal that does
+  **not** claim MCR is doing optimization work.
+- **The chip only appears on MCR-backed aliases** (`neuralwatt/…` and `…-long`),
+  never on `glm-5.1-fast`/`-flex`, `kimi-k2.6-*`, or direct base-model calls.
+
+The counter advances every ~0.5s until the model starts streaming, at which
+point the chip reverts to the standard view.
+
+> **Why not show the real compaction phase?** The gateway already emits the
+> ground truth — `event: mcr-status` SSE frames with `compacting` / `warming` /
+> `idle` phases ([`inference_frontend#3916`](https://github.com/neuralwatt/inference_frontend/issues/3916)).
+> A Pi extension on the current Pi versions (v0.72/0.73) **cannot observe those
+> frames**: the only streaming hook (`message_update`) delivers a closed
+> `AssistantMessageEvent` union (text/thinking/toolcall only), there is no raw
+> SSE-event hook on the extension API, and the OpenAI-compatible stream is
+> consumed through the official `openai` SDK, which drops any non-chat-completion
+> SSE frame before the extension could see it. So the extension genuinely can't
+> tell prefill from compaction — the only honest indicator is a neutral
+> in-flight one. A phase-accurate chip is blocked on an upstream Pi capability
+> (a hook that surfaces raw provider SSE events). See
+> [`neuralwatt/inference_frontend#3954`](https://github.com/neuralwatt/inference_frontend/issues/3954)
+> and [tools#33](https://github.com/neuralwatt/neuralwatt-tools/issues/33).
+
+### Verifying the chip behaviour
+
+There's no automated TUI harness, so verify by hand after copying the updated
+extension into `~/.pi/agent/extensions/`:
+
+1. **Normal fast turn** — on `neuralwatt/glm-5.1-long`, send a short prompt that
+   responds within a few seconds. The chip should stay on `MCR <fp> | drop<N>`
+   the whole time; **no** `working…` / `optimizing context…` should ever appear.
+2. **Long turn** — send a large prompt (or one that takes >6s to first token).
+   After the grace window the chip should switch to `MCR <fp> | working… Ns`
+   with the counter advancing, then revert to the standard view the instant the
+   model starts streaming.
+3. **Non-MCR model** — switch to `glm-5.1-fast` / `glm-5.1-flex` / direct
+   `zai-org/GLM-5.1-FP8` and send any prompt, including the first message. The
+   `nw-mcr` chip should be empty and stay empty — no `working…`, no MCR
+   fingerprint. (Regression check for [tools#33](https://github.com/neuralwatt/neuralwatt-tools/issues/33).)
+
+The extension logs each session start with its version and the in-flight
+transitions to `~/.pi/agent/extensions/neuralwatt-mcr.log` — tail it to confirm
+which revision is loaded.
 
 ## How context drop works
 
@@ -110,13 +166,18 @@ After:  [anchor1, anchor2, anchor3, recent_36, ..., recent_85]
 
 ## MCR vs non-MCR models
 
-The extension only activates for MCR-capable models. These are detected by model ID:
+The extension only activates for MCR-backed aliases. These are detected by model ID:
 
 - IDs with the `neuralwatt/` prefix (e.g., `neuralwatt/glm-5.1-long`)
 - IDs ending in `-long` (indicates a 1M virtual context window)
-- Base model IDs starting with `zai-org/`, `moonshotai/`, `glm-5`, `kimi-k2`
 
-For non-MCR models the extension stays out of the way — Pi behaves exactly as it does without the extension installed.
+Everything else — `glm-5.1-fast`, `glm-5.1-flex`, `kimi-k2.6-fast`/`-flex`, and
+direct base-model IDs like `zai-org/GLM-5.1-FP8` or `moonshotai/...` — is **not**
+MCR-backed (no server-side compaction), so the extension stays fully out of the
+way: no context drop, no MCR/`working…` chip, no fingerprint handling. Pi behaves
+exactly as it does without the extension installed. (Earlier versions matched
+those base-model/fast/flex IDs too and wrongly lit the chip on them — see
+[tools#33](https://github.com/neuralwatt/neuralwatt-tools/issues/33).)
 
 ## Known caveats
 
@@ -136,12 +197,13 @@ For non-MCR models the extension stays out of the way — Pi behaves exactly as 
 Pi extension (neuralwatt-mcr.ts)
   |
   +- after_provider_response   reads X-MCR-* headers
-  +- message_update            clears in-flight chip on first model delta (#3914)
+  +- message_update            clears in-flight chip on first model delta
   +- message_end               reads response body mcr/energy (fallback);
                                  backstop for clearing in-flight chip
   +- context                   drops messages per safe_drop_before
   +- before_provider_request   sends X-MCR-Session-FP header;
-                                 starts in-flight chip (#3914)
+                                 starts neutral in-flight chip (silent until
+                                 a long wait — never claims "optimizing")
   +- session_before_compact    cancels Pi compaction when MCR active
   +- session_start             resets state (incl. in-flight chip)
   +- session_shutdown          clears status bar (incl. in-flight ticker)

--- a/plugins/pi/extensions/neuralwatt-mcr.ts
+++ b/plugins/pi/extensions/neuralwatt-mcr.ts
@@ -4,6 +4,12 @@ import * as path from "node:path";
 import * as os from "node:os";
 import { randomUUID } from "node:crypto";
 
+// Bump on any user-facing behaviour change. Surfaced in the extension log so a
+// session's behaviour can be tied to a specific revision when triaging reports.
+//   2.0.0 — honest in-flight chip (tools#33 / inference_frontend#3954):
+//           neutral "working…" label, silent grace window, tightened MCR gating.
+const EXTENSION_VERSION = "2.0.0";
+
 const MCR_ANCHOR_USER_MESSAGES = 3;
 
 const LOG_FILE = path.join(
@@ -51,10 +57,17 @@ interface SessionState {
   contextTokens: number;
   lastMcrMeta: MCRMetadata | null;
   lastEnergy: EnergyData | null;
-  // Issue #3914: in-flight request UX. When an MCR request is sent we flip
-  // ``inFlightSince`` to the wall-clock send time so the chip can show
-  // "optimizing context…" until the response stream produces real model
-  // output. Cleared on first ``message_update`` or on ``message_end``.
+  // In-flight request UX. When an MCR request is sent we record the wall-clock
+  // send time so the chip can surface a neutral "working…" indicator on long
+  // waits, and cleared on the first ``message_update`` / ``message_end``.
+  //
+  // HONESTY NOTE (tools#33 / inference_frontend#3954): this is a wall-clock
+  // proxy, NOT a real compaction signal. The extension cannot observe whether
+  // the gateway is actually compacting — see ``markRequestSent`` for why Pi's
+  // API doesn't surface the gateway's ``mcr-status`` SSE frames. So the chip
+  // must NOT claim "optimizing context"; it can only honestly say a request is
+  // in flight. We also stay silent for the first few seconds so ordinary turns
+  // (the ~96% with no compaction) show nothing at all.
   inFlightSince: number | null;
   inFlightTickerHandle: NodeJS.Timeout | null;
 }
@@ -72,20 +85,38 @@ const state: SessionState = {
   inFlightTickerHandle: null,
 };
 
-// Issue #3914: how often to refresh the chip while the in-flight indicator
-// is showing, so the elapsed counter advances visibly. 500ms is fast enough
-// to feel live but well below the refresh budget of Pi's footer.
+// How often to refresh the chip while the in-flight indicator is showing, so
+// the elapsed counter advances visibly. 500ms is fast enough to feel live but
+// well below the refresh budget of Pi's footer.
 const IN_FLIGHT_TICK_MS = 500;
 
+// Honesty grace window (tools#33 / inference_frontend#3954): suppress the
+// in-flight indicator for the first few seconds of every request. Large MCR
+// prompts (100k+ tokens) have a naturally long prefill/TTFT — 10-60s — on
+// EVERY turn, with no compaction happening on the ~96% that don't compact.
+// The old chip labelled that ordinary latency "optimizing context…" for the
+// whole window, which read as "MCR is making every prompt slow" and drove
+// churn. We can't tell prefill from compaction (no SSE phase signal reaches
+// the extension), so the only honest move is: say nothing until the wait is
+// long enough that the user genuinely wants reassurance the model isn't hung,
+// and even then use a neutral label that doesn't assert MCR is doing work.
+const IN_FLIGHT_GRACE_MS = 6000;
+
+// Recognise ONLY the MCR-backed aliases. The MCR pipeline (server-side
+// compaction + 1M virtual context + the X-MCR-* response protocol) runs only
+// for the `neuralwatt/…-long` aliases; the base-model and fast/flex IDs route
+// straight to the provider with no compaction.
+//
+// tools#33: the earlier predicate also matched `zai-org/`, `moonshotai/`,
+// `glm-5`, and `kimi-k2`, so every fast/flex alias and direct base-model call
+// lit the in-flight chip and ran the context-drop / fp handlers — none of which
+// apply off-MCR. Nico reported "optimizing context" on non-long models. The
+// client always selects the alias (never the forwarded base name), so matching
+// the alias shape is sufficient and correct. This narrows every call site
+// (chip gating, context-drop, fp-set, compaction-suppression) to MCR-only,
+// which is the intended behaviour for all of them.
 function isMCRModel(modelId: string): boolean {
-  return (
-    modelId.includes("neuralwatt/") ||
-    modelId.includes("-long") ||
-    modelId.startsWith("zai-org/") ||
-    modelId.startsWith("moonshotai/") ||
-    modelId.startsWith("glm-5") ||
-    modelId.startsWith("kimi-k2")
-  );
+  return modelId.includes("neuralwatt/") || modelId.endsWith("-long");
 }
 
 function extractMCRFromHeaders(
@@ -175,9 +206,9 @@ function formatEnergy(joules: number): string {
   return `${(joules / 1000).toFixed(2)}kJ`;
 }
 
-// Issue #3914: render an in-flight elapsed-time stamp for the chip. Short
-// formats (<10s → "1.4s", >=10s → "12s", >=60s → "1m 5s") to keep the chip
-// from growing wide enough to push other footer widgets off-screen.
+// Render an in-flight elapsed-time stamp for the chip. Short formats (<10s →
+// "1.4s", >=10s → "12s", >=60s → "1m 5s") keep the chip from growing wide
+// enough to push other footer widgets off-screen.
 function formatElapsed(ms: number): string {
   if (ms < 10000) return `${(ms / 1000).toFixed(1)}s`;
   const seconds = Math.floor(ms / 1000);
@@ -318,23 +349,30 @@ export default function (pi: ExtensionAPI) {
   });
 
   function updateStatusBar(ctx: ExtensionContext) {
-    // Issue #3914: when an MCR request is in flight, show an "optimizing
-    // context…" indicator with elapsed time so the user knows the gateway
-    // is working (compaction or KV pre-warm) and the model hasn't hung.
-    // Dio's first-MCR-tester feedback (2026-05-28) named the exact failure
-    // mode this fixes: a silent multi-second pause looking identical to a
-    // crashed model. The in-flight indicator takes precedence over the
-    // standard "MCR <fp> | drop<N>" chip text — once the response stream
-    // produces real model output, ``markStreamProducing`` clears
-    // ``inFlightSince`` and the chip reverts to the standard view.
-    if (state.inFlightSince !== null) {
-      const elapsedMs = Date.now() - state.inFlightSince;
+    // In-flight indicator (tools#33 / inference_frontend#3954). HONESTY RULES:
+    //
+    //  * The extension cannot observe whether the gateway is compacting (Pi
+    //    doesn't surface the ``mcr-status`` SSE frames — see markRequestSent).
+    //    So we NEVER claim "optimizing context"; we only ever say a request is
+    //    in flight ("working…").
+    //  * We stay completely silent for the first IN_FLIGHT_GRACE_MS so normal
+    //    turns — including the long-but-uncompacted prefill that dominates real
+    //    usage — show nothing. Only a genuinely long wait surfaces the neutral
+    //    reassurance that the model hasn't hung.
+    //  * Once real model output starts, ``markStreamProducing`` clears
+    //    ``inFlightSince`` and the chip reverts to the standard MCR view.
+    const inFlightElapsedMs =
+      state.inFlightSince !== null ? Date.now() - state.inFlightSince : 0;
+    if (
+      state.inFlightSince !== null &&
+      inFlightElapsedMs >= IN_FLIGHT_GRACE_MS
+    ) {
       const fpPrefix = state.sessionFp
         ? `MCR ${state.sessionFp.slice(0, 8)} | `
         : "MCR | ";
       ctx.ui.setStatus(
         MCR_STATUS_KEY,
-        `${fpPrefix}optimizing context… ${formatElapsed(elapsedMs)}`,
+        `${fpPrefix}working… ${formatElapsed(inFlightElapsedMs)}`,
       );
     } else if (state.sessionFp) {
       const parts: string[] = [`MCR ${state.sessionFp.slice(0, 8)}`];
@@ -364,23 +402,43 @@ export default function (pi: ExtensionAPI) {
     }
   }
 
-  // Issue #3914: lifecycle helpers for the in-flight indicator. We bracket
-  // the wait window with ``markRequestSent`` (on before_provider_request)
-  // and ``markStreamProducing`` (on the first message_update / message_end
-  // that carries real model output).
+  // Lifecycle helpers for the in-flight indicator. We bracket the wait window
+  // with ``markRequestSent`` (on before_provider_request) and
+  // ``markStreamProducing`` (on the first message_update / message_end that
+  // carries real model output). The elapsed counter advances via a
+  // ``setInterval`` that re-calls ``updateStatusBar`` every ~0.5s.
   //
-  // The chip's elapsed counter advances via a ``setInterval`` that re-calls
-  // ``updateStatusBar`` every ~0.5s. Without the ticker the chip would
-  // freeze at "0.0s" until the response arrives, defeating the point.
+  // ── WHY THIS IS A NEUTRAL "working…" PROXY, NOT A REAL MCR PHASE SIGNAL ──
   //
-  // Forward-compatible note: the gateway (issue #3914 server side) also
-  // emits ``event: mcr-status`` SSE frames carrying {phase: compacting |
-  // warming | idle, elapsed_ms}. Pi's extension API does not currently
-  // surface raw SSE event types other than the standard message deltas
-  // (see types.d.ts::AssistantMessageEvent — only text/thinking/toolcall
-  // types reach extensions). When Pi adds an SSE-event hook we can swap
-  // the time-based estimate below for the server's authoritative phase
-  // signal and distinguish "compacting" from "warming" in the chip text.
+  // The gateway (inference_frontend #3916) emits the ground truth as
+  // ``event: mcr-status`` SSE frames carrying {phase: compacting | warming |
+  // idle, elapsed_ms}. The ideal chip would show "optimizing context…" ONLY
+  // while a ``compacting`` phase is live. That is NOT achievable from a Pi
+  // extension on the version this targets (Pi v0.72/0.73), verified against
+  // the published type defs:
+  //
+  //   1. The only stream hook is ``message_update``, whose payload is
+  //      ``assistantMessageEvent: AssistantMessageEvent`` (pi-ai types.d.ts).
+  //      That union is closed to text/thinking/toolcall/start/done/error —
+  //      there is no member that can carry a raw ``mcr-status`` frame.
+  //   2. There is no "raw SSE frame" / "stream event" hook anywhere on
+  //      ``ExtensionAPI`` (pi-coding-agent extensions/types.d.ts): the event
+  //      surface is session/agent/turn/message/tool lifecycle only.
+  //   3. The neuralwatt provider streams through pi-ai's openai-completions
+  //      handler, which consumes the response via the official ``openai`` SDK
+  //      (``client.chat.completions.create(...).withResponse()``). The SDK's
+  //      decoder yields only typed ``chat.completion.chunk`` objects; any SSE
+  //      frame with ``event: mcr-status`` is dropped by the SDK before pi-ai —
+  //      and therefore the extension — can ever see it.
+  //
+  // So the extension genuinely cannot tell prefill from compaction. Claiming
+  // "optimizing context" would be a lie on the ~96% of turns where nothing is
+  // compacted (the churn driver in #3954). The honest behaviour is: neutral
+  // "working…" label, only after a grace window. Path A (real phase-driven
+  // chip) is blocked on an upstream Pi capability: a hook that surfaces raw
+  // provider SSE events (or an OpenAI-compat passthrough for unknown event
+  // types) to extensions. Track that as a Pi feature request; revisit here
+  // once it ships.
   function markRequestSent(ctx: ExtensionContext) {
     state.inFlightSince = Date.now();
     if (state.inFlightTickerHandle !== null) {
@@ -490,12 +548,12 @@ export default function (pi: ExtensionAPI) {
     updateStatusBar(ctx);
   });
 
-  // Issue #3914: clear the in-flight indicator on the first message_update
-  // for an MCR model — at that point real model tokens are flowing, the
-  // "is it hung?" perception is gone, and the chip should revert to the
-  // standard MCR-fingerprint view. The MessageUpdateEvent fires for any
-  // assistant streaming update (text/thinking/toolcall deltas); we don't
-  // need to narrow further since any of these prove the wait is over.
+  // Clear the in-flight indicator on the first message_update for an MCR
+  // model — at that point real model tokens are flowing, the "is it hung?"
+  // perception is gone, and the chip should revert to the standard
+  // MCR-fingerprint view. The MessageUpdateEvent fires for any assistant
+  // streaming update (text/thinking/toolcall deltas); we don't need to narrow
+  // further since any of these prove the wait is over.
   pi.on("message_update", async (event, ctx) => {
     if (event.message.role !== "assistant") return;
     if (!isMCRModel(ctx.model?.id || "")) return;
@@ -506,9 +564,9 @@ export default function (pi: ExtensionAPI) {
     if (event.message.role !== "assistant") return;
     if (!isMCRModel(ctx.model?.id || "")) return;
 
-    // Issue #3914: backstop — if a response was short enough that no
-    // message_update ever fired, message_end is the latest possible
-    // chance to clear the indicator before it gets stale.
+    // Backstop — if a response was short enough that no message_update ever
+    // fired, message_end is the latest possible chance to clear the indicator
+    // before it gets stale.
     markStreamProducing(ctx);
 
     const msg = event.message as Record<string, unknown>;
@@ -637,12 +695,13 @@ export default function (pi: ExtensionAPI) {
 
     const payload = event.payload as Record<string, unknown>;
 
-    // Issue #3914: start the in-flight indicator. The chip shows
-    // "optimizing context… 1.4s" with the elapsed counter advancing every
-    // ~0.5s until the model starts producing real output (handled in
-    // ``message_update``). For MCR-long requests this window can be
-    // multiple seconds (compaction + KV pre-warm + TTFT); without the
-    // indicator the chat UI is indistinguishable from a hung model.
+    // Start the in-flight indicator. It stays silent for IN_FLIGHT_GRACE_MS;
+    // only on a genuinely long wait does it surface a neutral
+    // "working… 12s" so the chat UI isn't indistinguishable from a hung
+    // model. It deliberately does NOT claim "optimizing context" — the
+    // extension can't observe whether compaction is happening (see
+    // ``markRequestSent`` for the Pi-API limitation that blocks the real
+    // phase signal).
     markRequestSent(ctx);
 
     // Upgrade the X_NW_CONVERSATION_ID env var (seeded with a UUID at
@@ -728,7 +787,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("session_start", async (_event, ctx) => {
-    nwlog("session_start", {});
+    nwlog("session_start", { extension_version: EXTENSION_VERSION });
     state.sessionFp = null;
     state.safeDropBefore = 0;
     state.storedThrough = 0;
@@ -737,7 +796,7 @@ export default function (pi: ExtensionAPI) {
     state.contextTokens = 0;
     state.lastMcrMeta = null;
     state.lastEnergy = null;
-    // Issue #3914: clear any in-flight indicator left over from a prior
+    // Clear any in-flight indicator left over from a prior
     // session (defensive — session_start would normally fire after any
     // active request has completed, but a forced restart or fork can land
     // here while inFlightSince is still set).
@@ -791,7 +850,7 @@ export default function (pi: ExtensionAPI) {
       total_energy_joules: state.totalEnergyJoules,
       session_turns: state.sessionTurns,
     });
-    // Issue #3914: tear down the in-flight ticker so the interval handle
+    // Tear down the in-flight ticker so the interval handle
     // doesn't outlive the session.
     state.inFlightSince = null;
     if (state.inFlightTickerHandle !== null) {


### PR DESCRIPTION
## What this fixes

The `nw-mcr` in-flight chip was a **time-based proxy**: it showed `optimizing context… Ns` for the *entire* request→first-token window (the full TTFT) on **every** MCR request, regardless of whether compaction was actually happening. MCR prompts are 100k+ tokens, so that prefill window is naturally 10–60s — users saw "optimizing context" on nearly every prompt, for the whole wait, even though real context compaction happens on only a small fraction of turns. It labelled ordinary large-prompt prefill latency as MCR's doing, and that drove the customer-churn cluster (xenofembutch, Rxzlion, Nico, Angel — see [`inference_frontend#3954`](https://github.com/neuralwatt/inference_frontend/issues/3954)): *"optimizing context makes the model unbearably slow," "almost every prompt, 10–60s, never stops."*

## Which path: **Path B (fallback)** — Path A is not possible

**Path A** (the ideal: wire the chip to the gateway's real `event: mcr-status` SSE phases from [`inference_frontend#3916`](https://github.com/neuralwatt/inference_frontend/issues/3916), show "optimizing context" *only* while a `compacting` phase is live) **is not achievable from a Pi extension on the targeted Pi versions (v0.72 / v0.73).** Verified against the published type definitions and compiled provider code:

1. **Only streaming hook is `message_update`**, whose payload is `assistantMessageEvent: AssistantMessageEvent` (`pi-ai` `types.d.ts`). That union is **closed** — `start` / `text_*` / `thinking_*` / `toolcall_*` / `done` / `error`. There is no member that can carry a raw `mcr-status` frame.
2. **No raw-SSE / stream-event hook exists** anywhere on `ExtensionAPI` (`pi-coding-agent` `extensions/types.d.ts`). The event surface is session / agent / turn / message / tool lifecycle only.
3. **The stream is consumed via the official `openai` SDK.** The neuralwatt provider routes through `pi-ai`'s `openai-completions` handler, which does `client.chat.completions.create(...).withResponse()` and iterates `for await (const chunk of openaiStream)`. The SDK's decoder yields only typed `chat.completion.chunk` objects; any SSE frame with `event: mcr-status` is **dropped by the SDK** before `pi-ai` — and therefore the extension — can ever see it.

So the extension genuinely cannot distinguish prefill from compaction. Continuing to claim "optimizing context" would be a lie on the ~96% of turns where nothing is compacted.

**What Path A needs (upstream Pi capability):** a hook that surfaces raw provider SSE events to extensions, or an OpenAI-compat passthrough for unknown SSE event types. Worth filing as a Pi feature request; once it ships we can swap the neutral proxy for the gateway's authoritative `compacting` / `warming` / `idle` phases. The blocker and evidence are documented inline in `markRequestSent` and the README so the next person doesn't re-investigate.

## Path B — the integrity floor (this PR)

- **Relabel `optimizing context…` → neutral `working… Ns`.** It truthfully says only that a request is in flight; it never asserts MCR is optimizing.
- **6s grace window.** Stay silent for the first few seconds so normal turns (including the long-but-uncompacted prefill that dominates real usage) show nothing. Only a genuinely long wait surfaces the neutral reassurance that the model hasn't hung.
- **Tighten `isMCRModel` to `neuralwatt/` + `-long` only** (closes the gating half of [#33](https://github.com/neuralwatt/neuralwatt-tools/issues/33)). The chip — and the context-drop / fp-set / compaction-suppression handlers — no longer fire on `glm-5.1-fast`/`-flex`, `kimi-k2.6-*`, or direct base-model calls. The client always selects the alias, so alias-shape matching is sufficient and correct for every call site.
- **Add `EXTENSION_VERSION` (`2.0.0`)**, logged on `session_start` so a session's behaviour can be tied to a revision when triaging.
- **README chip section rewritten** + manual verification steps (no TUI test harness exists in this repo).

### Overlap with #33

This PR also implements #33's gating fix (Option A: narrow `isMCRModel`). No conflict — if #33 lands separately first, this branch should rebase to keep a single narrowed predicate.

## What the user now sees

| Scenario | Before | After |
|---|---|---|
| **Normal fast turn** (responds in a few s) | `MCR <fp> \| optimizing context… Ns` the whole time | Just `MCR <fp> \| drop<N>` — silent, no in-flight chip |
| **Turn where MCR actually compacts** (long wait) | `optimizing context… Ns` (correct by accident) | `MCR <fp> \| working… Ns` after the grace window — honest "in flight", no false "optimizing" claim. *(The extension can't confirm it's compaction, so it won't claim so — that requires Path A.)* |
| **Long-prefill turn, no compaction** | `optimizing context… 10–60s` (the churn driver) | Silent until 6s, then neutral `working… Ns` — no longer blames MCR for normal prefill |
| **Non-MCR model** (`glm-5.1-fast`/`-flex`, direct base) | chip lit on every request, incl. first message | nothing — extension stays fully out of the way |

## Testing

- Typechecked the modified extension against `@mariozechner/pi-coding-agent@0.73.1` + `@types/node` with strict `tsc` — **zero new errors** (the two pre-existing loose-cast warnings are unchanged from `main`).
- No automated TUI harness in this repo; added a manual verification checklist to `plugins/pi/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)