### PR TITLE
revert(pi-ext): $-prefixed env-var refs break auth (revert #32)

### DIFF
--- a/plugins/pi/extensions/neuralwatt-mcr.ts
+++ b/plugins/pi/extensions/neuralwatt-mcr.ts
@@ -343,16 +343,9 @@ export default function (pi: ExtensionAPI) {
   // doesn't merge with the models.json-derived entry (different map), so we
   // have to re-state any field we need; only apiKey here, since baseUrl/api
   // flow through via the override-only branch of applyProviderConfig.
-  //
-  // Env-var references use the explicit `$NAME` form. Pi deprecated the
-  // bare-name auto-detection ("NEURALWATT_API_KEY") — it now warns and will
-  // stop resolving bare names in a future release, so we pass `$`-prefixed
-  // values. `CONV_ID_ENV` itself stays bare because it's also used for
-  // `process.env[CONV_ID_ENV]` access above; only the registerProvider value
-  // gets the `$` prefix.
   pi.registerProvider("neuralwatt", {
-    apiKey: "$NEURALWATT_API_KEY",
-    headers: { "X-NW-Conversation-ID": `$${CONV_ID_ENV}` },
+    apiKey: "NEURALWATT_API_KEY",
+    headers: { "X-NW-Conversation-ID": CONV_ID_ENV },
   });
 
   function updateStatusBar(ctx: ExtensionContext) {


### PR DESCRIPTION
## Why

#32 switched `registerProvider` `apiKey` / header values from bare env-var names (`NEURALWATT_API_KEY`) to `$`-prefixed (`$NEURALWATT_API_KEY`) to silence a Pi deprecation warning. **This breaks auth on Pi 0.73.x — every request returns `401 (no body)`.**

Confirmed live: env var is set, `models.json` uses the working bare form, but the extension's `registerProvider` override (which takes precedence) used the `$`-form, which does NOT resolve to the env value on the current Pi version → empty key → 401. Reported immediately after updating the extension.

The deprecation warning was **forward-looking** ("will no longer be detected in a *future* release") — the bare form still works today. #32 acted on it prematurely.

## Fix

Revert #32. Restores the bare form; auth works. The deprecation warning returns (cosmetic) but is harmless until Pi actually drops bare-name support.

## Follow-up

The real fix for the deprecation warning needs to be validated against the actual Pi version's env-var resolution before re-applying — likely it requires Pi to support `$`-prefix resolution (it may not on 0.73.x), or the change must also update `models.json` consistently. Tracking the deprecation warning separately; do NOT re-apply the `$`-prefix without a live auth test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)