### PR TITLE
feat(pi-ext): send extension version in X-NW-MCR-Ext-Version header (2.1.0)

### DIFF
--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -15,6 +15,7 @@ When you select a Neuralwatt MCR model (e.g., `neuralwatt/kimi-k2.6-long`, `neur
 - **Compaction suppression** — Cancels Pi's built-in compaction when MCR is active (the server handles it).
 - **Anchor protection** — Preserves the first 3 user messages (MCR's fingerprint anchors) so sessions stay stable.
 - **Energy + MCR status bar** — Adds `nw-mcr` (session fingerprint + current drop threshold) and `nw-energy` (cumulative energy + APC cache hit rate + compaction ratio) to Pi's footer.
+- **Version reporting** — Sends the extension version on every request as the `X-NW-MCR-Ext-Version` header so the gateway can log which client revision served a request (handy when triaging a report — server logs previously had no way to tell a user's extension version).
 
 ## Requirements
 
@@ -148,7 +149,9 @@ extension into `~/.pi/agent/extensions/`:
 
 The extension logs each session start with its version and the in-flight
 transitions to `~/.pi/agent/extensions/neuralwatt-mcr.log` — tail it to confirm
-which revision is loaded.
+which revision is loaded. The same version is also sent on the wire as the
+`X-NW-MCR-Ext-Version` request header, so the gateway logs it server-side for
+debugging too.
 
 ## How context drop works
 

--- a/plugins/pi/extensions/neuralwatt-mcr.ts
+++ b/plugins/pi/extensions/neuralwatt-mcr.ts
@@ -8,7 +8,10 @@ import { randomUUID } from "node:crypto";
 // session's behaviour can be tied to a specific revision when triaging reports.
 //   2.0.0 — honest in-flight chip (tools#33 / inference_frontend#3954):
 //           neutral "working…" label, silent grace window, tightened MCR gating.
-const EXTENSION_VERSION = "2.0.0";
+//   2.1.0 — send the extension version on the wire as X-NW-MCR-Ext-Version so
+//           the gateway can log which client revision served a request (server
+//           logs previously had no way to tell a user's extension version).
+const EXTENSION_VERSION = "2.1.0";
 
 const MCR_ANCHOR_USER_MESSAGES = 3;
 
@@ -319,14 +322,14 @@ export default function (pi: ExtensionAPI) {
   const MCR_STATUS_KEY = "nw-mcr";
   const ENERGY_STATUS_KEY = "nw-energy";
 
-  // ── X-NW-Conversation-ID header wiring ──────────────────────────────
+  // ── Outbound header wiring (X-NW-Conversation-ID, X-NW-MCR-Ext-Version) ──
   // pi-coding-agent's `before_provider_request` is a *body* hook — the
   // earlier `payload.headers[...]` mutation reached extension memory only,
   // never the HTTP wire. The documented per-request header path is
-  // `pi.registerProvider({ headers })`, whose values are env-var names that
+  // `pi.registerProvider({ headers })`, whose values are env-var NAMES that
   // the SDK re-reads from `process.env` on every stream
-  // (dist/core/resolve-config-value.js). Net: real HTTP header, no body
-  // touch, no APC impact.
+  // (dist/core/resolve-config-value.js). Net: real HTTP headers, no body
+  // touch, no APC impact. Both headers below ride this same mechanism.
   //
   // Boot order: we seed the env var with a UUID at extension load so any
   // request fired before the first `before_provider_request` tick still
@@ -338,6 +341,14 @@ export default function (pi: ExtensionAPI) {
   if (!process.env[CONV_ID_ENV]) {
     process.env[CONV_ID_ENV] = getUuidFallback();
   }
+  // X-NW-MCR-Ext-Version (2.1.0): surface the client extension
+  // version on the wire so the gateway can log which revision served a
+  // request — server logs previously had no way to tell a user's version.
+  // Unlike the conversation id, the version is static for the life of the
+  // process (it never changes at runtime), so we seed it once at load and
+  // never touch it again — no upgrade-on-hook logic needed.
+  const EXT_VERSION_ENV = "X_NW_MCR_EXT_VERSION";
+  process.env[EXT_VERSION_ENV] = EXTENSION_VERSION;
   // `apiKey` mirrors the env-var name from ~/.pi/agent/models.json so the
   // partial config doesn't shadow the existing auth. `storeProviderRequestConfig`
   // doesn't merge with the models.json-derived entry (different map), so we
@@ -345,7 +356,10 @@ export default function (pi: ExtensionAPI) {
   // flow through via the override-only branch of applyProviderConfig.
   pi.registerProvider("neuralwatt", {
     apiKey: "NEURALWATT_API_KEY",
-    headers: { "X-NW-Conversation-ID": CONV_ID_ENV },
+    headers: {
+      "X-NW-Conversation-ID": CONV_ID_ENV,
+      "X-NW-MCR-Ext-Version": EXT_VERSION_ENV,
+    },
   });
 
   function updateStatusBar(ctx: ExtensionContext) {


### PR DESCRIPTION
## Summary

The Pi MCR extension now sends its version on every request as the `X-NW-MCR-Ext-Version` HTTP header so the gateway can log which client revision served a request.

**Why:** When triaging a user report, server logs previously had no way to tell a user's extension version — we couldn't tie a session's behaviour to a specific client revision from the server side. This wires the version onto the wire so the gateway can log it for debugging.

## What changed

- Bump `EXTENSION_VERSION` `2.0.0` -> `2.1.0` (this header is the new feature).
- Add a new outbound header `X-NW-MCR-Ext-Version` carrying `EXTENSION_VERSION`, wired via the **same env-var mechanism** as `X-NW-Conversation-ID`: the value in `registerProvider`'s `headers` map is an env-var **name** that the Pi SDK re-reads from `process.env` on every stream (body mutation never reaches the wire). New const `EXT_VERSION_ENV = "X_NW_MCR_EXT_VERSION"`, seeded once at extension load.
- Unlike the conversation id, the version is static for the life of the process, so there's no upgrade-on-hook logic — seeded once and never touched again.
- The existing `nwlog("session_start", { extension_version })` is unchanged.
- Updated the header-wiring comment block and the plugin README to document the new header.

No changes to the status chip, dedup, or context-drop logic.

## Test plan

- This repo has no TS build/lint step (Pi consumes the `.ts` directly); changes are syntactically consistent with the existing file and mirror the proven `X-NW-Conversation-ID` wiring.
- Manual verification: install the updated extension into `~/.pi/agent/extensions/`, run a request against an MCR alias, and confirm the gateway logs `X-NW-MCR-Ext-Version: 2.1.0` server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)