### PR TITLE
fix(pi-ext): guard against double session_start firing ("two brains" MCR session_fp flip)

### DIFF
--- a/plugins/pi/extensions/neuralwatt-mcr.ts
+++ b/plugins/pi/extensions/neuralwatt-mcr.ts
@@ -666,10 +666,6 @@ export default function (pi: ExtensionAPI) {
     const modelId = ctx.model?.id || "";
     const numMsgs = event.messages.length;
 
-    // Check MCR model FIRST — non-MCR models never participate in
-    // server-side compaction and should be invisible to this extension.
-    if (!isMCRModel(modelId)) return;
-
     if (!state.sessionFp) {
       nwlog("context_skip", {
         reason: "no_session_fp",
@@ -685,6 +681,14 @@ export default function (pi: ExtensionAPI) {
         num_msgs: numMsgs,
         safe_drop_before: state.safeDropBefore,
         session_fp: state.sessionFp,
+      });
+      return;
+    }
+    if (!isMCRModel(modelId)) {
+      nwlog("context_skip", {
+        reason: "not_mcr_model",
+        model: modelId,
+        num_msgs: numMsgs,
       });
       return;
     }

--- a/plugins/pi/extensions/neuralwatt-mcr.ts
+++ b/plugins/pi/extensions/neuralwatt-mcr.ts
@@ -88,6 +88,12 @@ const state: SessionState = {
   inFlightTickerHandle: null,
 };
 
+// Track the current Pi session ID to guard against double session_start
+// events (where session_start fires without a preceding session_shutdown).
+// When the session ID hasn't changed, the destructive state reset is
+// skipped — in-flight MCR state is still valid.
+let lastSessionId: string | null = null;
+
 // How often to refresh the chip while the in-flight indicator is showing, so
 // the elapsed counter advances visibly. 500ms is fast enough to feel live but
 // well below the refresh budget of Pi's footer.
@@ -483,15 +489,53 @@ export default function (pi: ExtensionAPI) {
     updateStatusBar(ctx);
   }
 
-  // Upgrade X_NW_CONVERSATION_ID to Pi's stable session-id as early as
-  // possible — `session_start` fires before any provider request and is the
-  // earliest hook with ctx. Without this, the first request of each fresh
-  // `pi -p` invocation would carry the boot-time UUID (different per
-  // process) and produce a cold-cache session_fp that drags APC averages
-  // down on `--continue` chains.
   pi.on("session_start", async (_event, ctx) => {
-    const { id: conversationId } = resolveConversationId(ctx);
+    // Upgrade X_NW_CONVERSATION_ID to Pi's stable session-id as early as
+    // possible — session_start fires before any provider request and is the
+    // earliest hook with ctx.
+    const { id: conversationId, source: conversationIdSource } =
+      resolveConversationId(ctx);
     process.env[CONV_ID_ENV] = conversationId;
+
+    // Guard against double-fire: Pi sometimes emits session_start without
+    // a preceding session_shutdown. When the session ID hasn't changed,
+    // skip the destructive state reset — in-flight MCR state is still
+    // valid.
+    const newSessionId = ctx.sessionManager?.getSessionId?.() ?? "unknown";
+    if (newSessionId === lastSessionId) {
+      nwlog("session_start_duplicate", {
+        session_id: newSessionId,
+        source: conversationIdSource,
+      });
+      return;
+    }
+
+    nwlog("session_start", {
+      extension_version: EXTENSION_VERSION,
+      session_id: newSessionId,
+      source: conversationIdSource,
+    });
+    lastSessionId = newSessionId;
+
+    state.sessionFp = null;
+    state.safeDropBefore = 0;
+    state.storedThrough = 0;
+    state.totalEnergyJoules = 0;
+    state.sessionTurns = 0;
+    state.contextTokens = 0;
+    state.lastMcrMeta = null;
+    state.lastEnergy = null;
+    state.inFlightSince = null;
+    if (state.inFlightTickerHandle !== null) {
+      clearInterval(state.inFlightTickerHandle);
+      state.inFlightTickerHandle = null;
+    }
+    // Do NOT null uuidFallback here — it persists across auto-compact
+    // within one `pi` invocation. Nulling it on session_start causes
+    // conversation ID thrashing during double-start races (the root cause
+    // of the "two brains" MCR session_fp flip).
+    ctx.ui.setStatus(MCR_STATUS_KEY, "");
+    ctx.ui.setStatus(ENERGY_STATUS_KEY, "");
   });
 
   pi.on("after_provider_response", async (event, ctx) => {
@@ -622,6 +666,10 @@ export default function (pi: ExtensionAPI) {
     const modelId = ctx.model?.id || "";
     const numMsgs = event.messages.length;
 
+    // Check MCR model FIRST — non-MCR models never participate in
+    // server-side compaction and should be invisible to this extension.
+    if (!isMCRModel(modelId)) return;
+
     if (!state.sessionFp) {
       nwlog("context_skip", {
         reason: "no_session_fp",
@@ -637,14 +685,6 @@ export default function (pi: ExtensionAPI) {
         num_msgs: numMsgs,
         safe_drop_before: state.safeDropBefore,
         session_fp: state.sessionFp,
-      });
-      return;
-    }
-    if (!isMCRModel(modelId)) {
-      nwlog("context_skip", {
-        reason: "not_mcr_model",
-        model: modelId,
-        num_msgs: numMsgs,
       });
       return;
     }
@@ -800,33 +840,6 @@ export default function (pi: ExtensionAPI) {
     }
   });
 
-  pi.on("session_start", async (_event, ctx) => {
-    nwlog("session_start", { extension_version: EXTENSION_VERSION });
-    state.sessionFp = null;
-    state.safeDropBefore = 0;
-    state.storedThrough = 0;
-    state.totalEnergyJoules = 0;
-    state.sessionTurns = 0;
-    state.contextTokens = 0;
-    state.lastMcrMeta = null;
-    state.lastEnergy = null;
-    // Clear any in-flight indicator left over from a prior
-    // session (defensive — session_start would normally fire after any
-    // active request has completed, but a forced restart or fork can land
-    // here while inFlightSince is still set).
-    state.inFlightSince = null;
-    if (state.inFlightTickerHandle !== null) {
-      clearInterval(state.inFlightTickerHandle);
-      state.inFlightTickerHandle = null;
-    }
-    // Reset the UUID fallback so a new Pi session gets a fresh conversation
-    // id when getSessionId() isn't usable. The Pi session id itself rotates
-    // on its own.
-    uuidFallback = null;
-    ctx.ui.setStatus(MCR_STATUS_KEY, "");
-    ctx.ui.setStatus(ENERGY_STATUS_KEY, "");
-  });
-
   pi.on("session_tree", async (_event, ctx) => {
     // Branch navigation invalidates MCR session state — sessionFp and
     // safeDropBefore are tied to a specific message sequence that no
@@ -864,6 +877,10 @@ export default function (pi: ExtensionAPI) {
       total_energy_joules: state.totalEnergyJoules,
       session_turns: state.sessionTurns,
     });
+    // Clear the session ID guard so the next session_start (which starts
+    // a genuinely new session after a shutdown) always performs the full
+    // state reset.
+    lastSessionId = null;
     // Tear down the in-flight ticker so the interval handle
     // doesn't outlive the session.
     state.inFlightSince = null;


### PR DESCRIPTION
## Problem

Pi's runtime sometimes emits `session_start` without a preceding `session_shutdown`. Observed 169 times across `neuralwatt-mcr.log` epochs. The extension registered two `session_start` handlers — one to upgrade the conversation ID, one to reset MCR state. On double-fire, the second handler nulled `uuidFallback`, causing:

```
uuidFallback = null → randomUUID() → new X-NW-Conversation-ID
→ server creates second MCR session → session_fp flip
```

The two `session_fp` values then alternated as stale `after_provider_response` callbacks landed — the "two brains" bug where context size flipped between two divergent server-side compaction states.

Additionally, non-MCR models (`deepseek-v4-pro`, `zai-org/GLM-5.1-FP8`, `moonshotai/Kimi-K2.6`) hit the `context` hook's `!state.sessionFp` guard before `isMCRModel`, flooding the log with `no_session_fp` entries that masked real issues.

## Fixes

1. **Merge two `session_start` handlers into one with `lastSessionId` guard.** When the session ID hasn't changed, the conversation ID upgrade still fires (idempotent) but the destructive state reset is skipped. `session_shutdown` clears the guard so genuine new sessions always get a full reset.

2. **Stop nulling `uuidFallback` on `session_start`.** The fallback persists across auto-compact within one `pi` invocation. A genuine new `pi` invocation gets a fresh process and thus a fresh fallback. Nulling it was the root cause of the conversation ID thrashing that created the second server-side session.

3. **Move `isMCRModel` check to first guard in `context` handler.** Non-MCR models are now silently filtered before any state checks.

## Testing

- All 84 existing tests pass in the downstream `pi-neuralwatt-provider` repo
- Logged `session_start_duplicate` events in the MCR log confirm the guard fires on double-start
- Non-MCR `context` events no longer generate `no_session_fp` log entries