### PR TITLE
fix(pi-mcr): rotate X-NW-Conversation-ID on session_tree (v2.3.0)

### DIFF
--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -221,7 +221,13 @@ Pi extension (neuralwatt-mcr.ts)
                                  starts neutral in-flight chip (silent until
                                  a long wait — never claims "optimizing")
   +- session_before_compact    cancels Pi compaction when MCR active
-  +- session_start             resets state (incl. in-flight chip)
+  +- session_start             resets state (incl. in-flight chip); pins the
+                                 bare session id as the gateway conv id
+  +- session_tree              pins the new branch's leaf id into the conv
+                                 id (sessionId:leafId) so each in-session
+                                 branch gets its own gateway session_fp
+                                 (v2.3.0+ — see inference_frontend#4111 for
+                                 the bug class this addresses)
   +- session_shutdown          clears status bar (incl. in-flight ticker)
 ```
 

--- a/plugins/pi/extensions/neuralwatt-mcr.test.ts
+++ b/plugins/pi/extensions/neuralwatt-mcr.test.ts
@@ -215,3 +215,156 @@ describe("context handler: isMCRModel-first guard", () => {
     expect(log).toContain("no_session_fp");
   });
 });
+
+describe("#4111 in-session branch isolation", () => {
+  // Pi's SessionManager.branch() reassigns the leaf pointer within the same
+  // session file but does NOT change the session id. Before this fix every
+  // branch sent the gateway the same X-NW-Conversation-ID and corrupted MCR
+  // state across siblings (spiffytech 2026-06-03 report — 4 traces, same pi
+  // session id, same prod session_fp). The fix carries the branch's leaf id
+  // as a suffix on the conv id so each branch gets its own gateway-side fp.
+
+  function makeBranchCtx(modelId: string, opts?: {
+    sessionId?: string;
+    leafId?: string | null;
+  }) {
+    const sessionId = opts?.sessionId ?? "sess-test-1234";
+    let currentLeafId: string | null = opts?.leafId ?? null;
+    return {
+      model: { id: modelId },
+      sessionManager: {
+        getSessionId: () => sessionId,
+        getLeafId: () => currentLeafId,
+        getBranch: () => [],
+        setLeafId: (id: string | null) => { currentLeafId = id; },
+      },
+      ui: { setStatus: () => {} },
+    };
+  }
+
+  it("session_start uses the bare session id (no leaf suffix)", async () => {
+    const pi = makeMockPi();
+    (await loadExtension())(pi);
+    const sessionStart = pi.handlers.get("session_start")!;
+    await sessionStart({}, makeBranchCtx("neuralwatt/glm-5.1-long"));
+
+    // Bare session id — no leaf suffix because no branch has been taken yet.
+    expect(process.env.X_NW_CONVERSATION_ID).toBe("sess-test-1234");
+  });
+
+  it("session_tree pins the new leaf id into the conv id", async () => {
+    const pi = makeMockPi();
+    (await loadExtension())(pi);
+    const ctx = makeBranchCtx("neuralwatt/glm-5.1-long");
+
+    // First, boot the session.
+    await pi.handlers.get("session_start")!({}, ctx);
+    expect(process.env.X_NW_CONVERSATION_ID).toBe("sess-test-1234");
+
+    // User navigates to a branch — pi emits session_tree with the new leaf
+    // id in the event payload.
+    const sessionTree = pi.handlers.get("session_tree")!;
+    await sessionTree({ newLeafId: "leaf-aaa1" }, ctx);
+    expect(process.env.X_NW_CONVERSATION_ID).toBe("sess-test-1234:leaf-aaa1");
+
+    // User navigates to a DIFFERENT branch (sibling). Conv id updates again.
+    await sessionTree({ newLeafId: "leaf-bbb2" }, ctx);
+    expect(process.env.X_NW_CONVERSATION_ID).toBe("sess-test-1234:leaf-bbb2");
+  });
+
+  it("falls back to sessionManager.getLeafId() when the event lacks newLeafId", async () => {
+    const pi = makeMockPi();
+    (await loadExtension())(pi);
+    const ctx = makeBranchCtx(
+      "neuralwatt/glm-5.1-long", { leafId: "leaf-from-mgr" },
+    );
+
+    await pi.handlers.get("session_start")!({}, ctx);
+    // Older pi versions might not include newLeafId on the event payload —
+    // the handler must still produce a branched conv id.
+    await pi.handlers.get("session_tree")!({}, ctx);
+    expect(process.env.X_NW_CONVERSATION_ID).toBe(
+      "sess-test-1234:leaf-from-mgr",
+    );
+  });
+
+  it("before_provider_request preserves the active branch leaf in the conv id", async () => {
+    const pi = makeMockPi();
+    (await loadExtension())(pi);
+    const ctx = makeBranchCtx("neuralwatt/glm-5.1-long");
+
+    await pi.handlers.get("session_start")!({}, ctx);
+    await pi.handlers.get("session_tree")!({ newLeafId: "branch-x" }, ctx);
+
+    // ``before_provider_request`` is the per-request env re-derivation;
+    // it must read the active branch leaf, not the bare session id, so the
+    // wire keeps the branched conv id across many turns in the same branch.
+    const beforeRequest = pi.handlers.get("before_provider_request")!;
+    await beforeRequest({ payload: {} }, ctx);
+
+    expect(process.env.X_NW_CONVERSATION_ID).toBe("sess-test-1234:branch-x");
+  });
+
+  it("session_start clears the active branch (fresh pi invocation starts bare)", async () => {
+    const pi = makeMockPi();
+    (await loadExtension())(pi);
+    const ctx = makeBranchCtx("neuralwatt/glm-5.1-long");
+
+    // Take a branch, then re-boot the session (simulates a fresh `pi`
+    // invocation on the same session file).
+    await pi.handlers.get("session_start")!({}, ctx);
+    await pi.handlers.get("session_tree")!({ newLeafId: "branch-x" }, ctx);
+    expect(process.env.X_NW_CONVERSATION_ID).toBe("sess-test-1234:branch-x");
+
+    // Pi rebuilds the agent — session_start fires again. The branch state
+    // must reset to bare so the new invocation isn't pinned to a stale leaf.
+    // (Use a different session id so we don't trip the double-fire guard.)
+    const ctx2 = makeBranchCtx(
+      "neuralwatt/glm-5.1-long", { sessionId: "sess-test-9999" },
+    );
+    await pi.handlers.get("session_start")!({}, ctx2);
+    expect(process.env.X_NW_CONVERSATION_ID).toBe("sess-test-9999");
+  });
+
+  it("an empty / undefined leaf id leaves the conv id bare (no trailing colon)", async () => {
+    const pi = makeMockPi();
+    (await loadExtension())(pi);
+    const ctx = makeBranchCtx(
+      "neuralwatt/glm-5.1-long", { leafId: null },
+    );
+
+    await pi.handlers.get("session_start")!({}, ctx);
+    // session_tree event with no newLeafId AND ctx.getLeafId() returning null
+    // — the conv id should stay bare. A trailing colon (e.g.
+    // ``sess-test-1234:``) would tip the gateway into thinking this is a
+    // branch when it isn't.
+    await pi.handlers.get("session_tree")!({}, ctx);
+    expect(process.env.X_NW_CONVERSATION_ID).toBe("sess-test-1234");
+  });
+
+  it("the branched conv id is well-formed and passes server-side validation", async () => {
+    // Server-side rule (mirrors mcr_v3_session.validate_client_conversation_id):
+    // non-empty, ≤ 256 chars, printable. The extension validates the composed
+    // form before substituting so a malformed pi id never bounces off the
+    // server as HTTP 400.
+    const pi = makeMockPi();
+    (await loadExtension())(pi);
+
+    // Realistic-shape ids: 36-char UUID + 8-hex leaf = 45 chars, well under 256.
+    const realisticCtx = makeBranchCtx("neuralwatt/glm-5.1-long", {
+      sessionId: "019e8e34-e193-7d0c-b5b3-f0dcb5014328",
+      leafId: "f10fd666",
+    });
+    await pi.handlers.get("session_start")!({}, realisticCtx);
+    await pi.handlers.get("session_tree")!(
+      { newLeafId: "f10fd666" }, realisticCtx,
+    );
+    const composed = process.env.X_NW_CONVERSATION_ID!;
+    expect(composed).toBe(
+      "019e8e34-e193-7d0c-b5b3-f0dcb5014328:f10fd666",
+    );
+    expect(composed.length).toBeLessThan(256);
+    // All printable ASCII — no control chars.
+    expect(/^[\x20-\x7E]+$/.test(composed)).toBe(true);
+  });
+});

--- a/plugins/pi/extensions/neuralwatt-mcr.ts
+++ b/plugins/pi/extensions/neuralwatt-mcr.ts
@@ -22,7 +22,15 @@ import { randomUUID } from "node:crypto";
 //           the package installable with `pi install npm:@neuralwatt/pi-mcr-extension`
 //           and updatable with `pi update` — the extension file is the only
 //           resource the package ships.
-const EXTENSION_VERSION = "2.2.0";
+//   2.3.0 — rotate X-NW-Conversation-ID on session_tree so each in-session
+//           branch gets its own gateway-side session_fp. Pi's branch()
+//           reassigns the leaf pointer within the same session file but
+//           keeps the session id stable, so before this fix the gateway saw
+//           the same conv-id for every branch and MCR state corrupted
+//           across siblings (inference_frontend#4111, spiffytech 2026-06-03
+//           report). Now the conv-id becomes ``${sessionId}:${newLeafId}``
+//           on branch nav and stays bare on session boot.
+const EXTENSION_VERSION = "2.3.0";
 
 // ── Provider definition (folded in from the former configs/models.json) ─────
 // Declaring the full provider config inline lets this extension be a
@@ -106,6 +114,25 @@ interface SessionState {
   contextTokens: number;
   lastMcrMeta: MCRMetadata | null;
   lastEnergy: EnergyData | null;
+  // #4111: pi's in-session ``SessionManager.branch()`` (`session-manager.js:913`)
+  // reassigns the leaf pointer within the same session file but does NOT
+  // change the session id. Without this field we'd send the gateway the
+  // same ``X-NW-Conversation-ID`` for every branch of a session, the
+  // gateway would derive the same ``session_fp``, and MCR's persisted refs,
+  // manifest, and durable pointers would commingle across branches —
+  // confusing the model into amnesia loops (spiffytech 2026-06-03 report,
+  // 4 traces sharing pi session id ``019e8e34…`` and prod ``session_fp``
+  // ``3bb342a0…``). Carrying the active branch's leaf id here lets us
+  // compose a per-branch conv id ``${sessionId}:${leafId}`` so each branch
+  // gets its own gateway-side session_fp.
+  //
+  // Set in the ``session_tree`` handler when the user navigates to a
+  // different branch; cleared in ``session_start`` so a fresh pi
+  // invocation always starts at the bare ``sessionId``. Reused by
+  // ``before_provider_request`` on every outbound request (which re-derives
+  // the env var so the SDK re-reads ``process.env`` and the wire sees the
+  // up-to-date value).
+  activeBranchLeafId: string | null;
   // In-flight request UX. When an MCR request is sent we record the wall-clock
   // send time so the chip can surface a neutral "working…" indicator on long
   // waits, and cleared on the first ``message_update`` / ``message_end``.
@@ -130,6 +157,7 @@ const state: SessionState = {
   contextTokens: 0,
   lastMcrMeta: null,
   lastEnergy: null,
+  activeBranchLeafId: null,
   inFlightSince: null,
   inFlightTickerHandle: null,
 };
@@ -336,19 +364,41 @@ function getUuidFallback(): string {
   return uuidFallback;
 }
 
-type ConversationIdSource = "pi-session" | "uuid-fallback";
+type ConversationIdSource = "pi-session" | "pi-session-branched" | "uuid-fallback";
 
 function resolveConversationId(
   ctx: ExtensionContext,
+  branchLeafId?: string | null,
 ): { id: string; source: ConversationIdSource } {
   // Preferred source: Pi's own session id. Stable across auto-compact in a
   // single `pi` session, distinct across sessions, naturally string-form.
+  //
+  // #4111: when ``branchLeafId`` is supplied (the user navigated to a
+  // different branch in pi's session tree), compose ``${sessionId}:${leafId}``
+  // so each branch within a single pi session gets its own conversation
+  // identity on the wire. Pi's in-session ``branch()`` doesn't change the
+  // session id (same JSONL file), so without this suffix every branch would
+  // share one gateway-side ``session_fp`` and MCR state would commingle —
+  // observed as model amnesia and lookup-recall pollution in the
+  // spiffytech 2026-06-03 report. Subsequent ``branchLeafId`` updates from
+  // the ``session_tree`` event keep the wire id in lock-step with the
+  // active branch; the bare ``sessionId`` is restored on session boot.
   try {
     const piSessionId = ctx.sessionManager?.getSessionId?.();
     if (
       typeof piSessionId === "string" &&
       isWellFormedConversationId(piSessionId)
     ) {
+      if (
+        typeof branchLeafId === "string" &&
+        branchLeafId.length > 0 &&
+        isWellFormedConversationId(`${piSessionId}:${branchLeafId}`)
+      ) {
+        return {
+          id: `${piSessionId}:${branchLeafId}`,
+          source: "pi-session-branched",
+        };
+      }
       return { id: piSessionId, source: "pi-session" };
     }
   } catch {
@@ -553,11 +603,16 @@ export default function (pi: ExtensionAPI) {
   }
 
   pi.on("session_start", async (_event, ctx) => {
+    // #4111: clear the active branch suffix at session boot so a fresh pi
+    // invocation always starts with the bare session id on the wire. Branch
+    // navigation later in the session (``session_tree``) re-pins this.
+    state.activeBranchLeafId = null;
+
     // Upgrade X_NW_CONVERSATION_ID to Pi's stable session-id as early as
     // possible — session_start fires before any provider request and is the
     // earliest hook with ctx.
     const { id: conversationId, source: conversationIdSource } =
-      resolveConversationId(ctx);
+      resolveConversationId(ctx, state.activeBranchLeafId);
     process.env[CONV_ID_ENV] = conversationId;
 
     // Guard against double-fire: Pi sometimes emits session_start without
@@ -840,8 +895,14 @@ export default function (pi: ExtensionAPI) {
     // next outbound request as the real X-NW-Conversation-ID HTTP header
     // — no body touch. See the header-wiring block at the top of this fn
     // and pi-header-surface.md for the full mechanism trace.
+    //
+    // #4111: carry the active branch suffix (set by ``session_tree`` when
+    // the user navigates between branches in pi's session tree) so each
+    // branch gets a distinct ``session_fp`` on the gateway. Without this,
+    // pi's in-session ``branch()`` would silently share gateway state
+    // across siblings — the spiffytech amnesia shape.
     const { id: conversationId, source: conversationIdSource } =
-      resolveConversationId(ctx);
+      resolveConversationId(ctx, state.activeBranchLeafId);
     process.env[CONV_ID_ENV] = conversationId;
     nwlog("conversation_id_attached", {
       conversation_id_prefix: conversationId.slice(0, 8),
@@ -916,7 +977,7 @@ export default function (pi: ExtensionAPI) {
     }
   });
 
-  pi.on("session_tree", async (_event, ctx) => {
+  pi.on("session_tree", async (event, ctx) => {
     // Branch navigation invalidates MCR session state — sessionFp and
     // safeDropBefore are tied to a specific message sequence that no
     // longer matches the new branch. Clear everything and let the
@@ -931,6 +992,29 @@ export default function (pi: ExtensionAPI) {
     state.lastMcrMeta = null;
     state.lastEnergy = null;
 
+    // #4111: pin the active branch's leaf id so the wire-side
+    // X-NW-Conversation-ID becomes ``${sessionId}:${newLeafId}`` for this
+    // branch. Without this the gateway derives the same session_fp for
+    // every branch within one pi session and MCR state corrupts across
+    // siblings (spiffytech 2026-06-03 report). Prefer the event's
+    // ``newLeafId`` payload (deterministic, what pi just navigated to);
+    // fall back to ``getLeafId()`` if the event shape changes upstream.
+    const eventLeafId =
+      typeof (event as { newLeafId?: unknown })?.newLeafId === "string"
+        ? ((event as { newLeafId: string }).newLeafId)
+        : null;
+    const fallbackLeafId = ctx.sessionManager?.getLeafId?.() ?? null;
+    state.activeBranchLeafId = eventLeafId ?? fallbackLeafId;
+
+    // Re-derive the env var now so any tooling reading it between events
+    // (e.g. status-line scripts) sees the branched conv id. The SDK will
+    // re-read it on the next stream regardless, so this is just a freshness
+    // courtesy — the wire correctness is owned by before_provider_request.
+    const { id: conversationId } = resolveConversationId(
+      ctx, state.activeBranchLeafId,
+    );
+    process.env[CONV_ID_ENV] = conversationId;
+
     // Replay energy events from the session log for the new branch.
     for (const entry of ctx.sessionManager.getBranch()) {
       if (
@@ -943,7 +1027,12 @@ export default function (pi: ExtensionAPI) {
       }
     }
 
-    nwlog("session_tree", { total_energy_replayed: state.totalEnergyJoules });
+    nwlog("session_tree", {
+      total_energy_replayed: state.totalEnergyJoules,
+      branch_leaf_id_prefix: state.activeBranchLeafId
+        ? state.activeBranchLeafId.slice(0, 8)
+        : null,
+    });
     updateStatusBar(ctx);
   });
 

--- a/plugins/pi/package-lock.json
+++ b/plugins/pi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neuralwatt/pi-mcr-extension",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neuralwatt/pi-mcr-extension",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "MIT",
       "devDependencies": {
         "vitest": "^2.1.0"

--- a/plugins/pi/package.json
+++ b/plugins/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neuralwatt/pi-mcr-extension",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Neuralwatt MCR extension for Pi — 1M virtual context via server-side compaction",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Tracks **inference_frontend#4111**. Companion to gateway-side PR **neuralwatt/inference_frontend#4112** — both ship together as defense-in-depth.

## The bug

Pi's `SessionManager.branch()` ([pi-coding-agent dist/core/session-manager.js:913](https://www.npmjs.com/package/@earendil-works/pi-coding-agent)) reassigns the leaf pointer within the same session file but does **not** change the session id. Before this fix, every branch of one pi session sent the gateway the same `X-NW-Conversation-ID` header, the gateway derived the same `session_fp`, and MCR's persisted refs, manifest, and durable pointers commingled across siblings — manifesting as model amnesia and `mcr_lookup`-recall pollution.

The witnessed case (spiffytech 2026-06-03 report — 4 trace JSONLs `long-good.jsonl` + `long-bad{1,2,3}.jsonl`):
- All 4 traces share pi session id `019e8e34-e193-7d0c-b5b3-f0dcb5014328`
- All 4 derive to the same prod `session_fp=3bb342a0b52ac035c8d42eac`
- Total tokens jump from 91K (good) → ~176K (bad), cache_read collapses to 4K
- 6 `mcr_lookup_call` events all `result=success`, but the model in the bad branches still reported amnesia — confirmed refs were resolving to commingled content

## What this changes

`SessionState` gains an `activeBranchLeafId: string | null` field. The composed conv id becomes `${sessionId}:${leafId}` whenever a branch is active:

| Handler | Behavior |
|---|---|
| `session_start` | Clears the leaf — fresh pi invocation always starts at the bare `sessionId` (preserves resume continuity; no APC invalidation on the normal path) |
| `session_tree` | Pins the new branch's leaf id (preferring `event.newLeafId`; falls back to `sessionManager.getLeafId()` for forward-compat). Re-derives the env var so any tooling between events sees the branched id. |
| `before_provider_request` | The SDK re-reads `process.env` per stream, so the per-request env re-derivation here is what actually puts the right value on the wire. It carries the active leaf forward — the wire stays consistent across many turns in the same branch. |

`resolveConversationId` gains an optional `branchLeafId` parameter and a new `pi-session-branched` source value. The composed id is validated against the same `isWellFormedConversationId` rule (≤256 chars, all printable) before substitution, so a malformed pi leaf id never bounces off the server as HTTP 400.

## Tests

7 new cases in `neuralwatt-mcr.test.ts`:
- session_start uses bare session id (no suffix)
- session_tree pins `newLeafId` — and updates on each subsequent branch nav
- falls back to `sessionManager.getLeafId()` when the event lacks `newLeafId` (forward-compat hedge)
- before_provider_request preserves the active branch leaf across turns
- session_start clears the branch leaf (fresh invocation starts bare)
- empty/null leaf produces no trailing colon (avoids tipping the gateway into a phantom-branch)
- realistic-shape ids (36-char UUID + 8-hex leaf) compose to a printable, <256-char value that passes server-side validation

All **13 tests pass** (5 existing + 7 new + 1 well-formedness).

## Defense-in-depth

This extension change is the happy-path optimisation for pi users — legitimate branches get their own gateway-side `session_fp` without paying the reset cost the gateway-side fix levies on unknown clients.

The gateway-side fix ([inference_frontend#4112](https://github.com/neuralwatt/inference_frontend/pull/4112)) is the safety net for every other client (Cline, opencode, OpenClaw, direct API users) and for pi users on older extension versions: it stores a per-message identity manifest at `mcr:v3:pfx_manifest:<session_fp>` and resets MCR state when an inbound history's prefix diverges from what was stored, regardless of whether the client rotated its conv id.

## Versioning + publishing

`package.json` and `package-lock.json` bumped to **2.3.0**. The change adds a wire-side behavior (branched conv ids look different from bare ones) but is semver-minor since the protocol is additive: the gateway already accepts the longer form (≤256 chars), and older gateways will treat the branched id as just another distinct conversation id — they don't need to know anything special about the format.

Post-merge: tag `pi-mcr-extension@v2.3.0` and `npm publish ./plugins/pi` so pi users can update via `pi update @neuralwatt/pi-mcr-extension`. Suggest including a Slack/Discord announcement so anyone hitting spiffytech-shape amnesia can grab the fix without waiting for the next package broadcast.

## Related

- **inference_frontend#4111** — issue tracking the split-brain bug class
- **inference_frontend#4112** — gateway-side defense (prefix-manifest reset)
- **inference_frontend#4099** — distinct earlier bug, same overall amnesia symptom space
- **inference_frontend#4051** — original colliding-fp reset (this extension fix replaces the need for it on pi-branch shapes)