### PR TITLE
fix(pi-ext): dual-instance guard + post-drop stale-window self-heal (#44)

### DIFF
--- a/plugins/pi/extensions/neuralwatt-mcr.test.ts
+++ b/plugins/pi/extensions/neuralwatt-mcr.test.ts
@@ -13,7 +13,7 @@
 // We run each test in an isolated $HOME so the extension's append-only log
 // file is observable and does not leak across tests.
 
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -98,11 +98,20 @@ beforeAll(async () => {
   extDefault = mod.default as (pi: MockPi) => void;
 });
 
+// tools#44: the dual-instance guard claims a process-global sentinel on
+// globalThis at activation. Every test below activates the extension at least
+// once, so the sentinel must be cleared between tests or the second test's
+// activation would be (correctly!) blocked as a dual instance.
+function clearDualInstanceSentinel() {
+  delete (globalThis as Record<string, unknown>).__NEURALWATT_MCR_ACTIVE__;
+}
+
 beforeEach(() => {
   // Reset the env-var seeds and the log between tests. Re-seed the conversation
   // id the same way the extension does at module load (it only seeds once).
   delete process.env.X_NW_CONVERSATION_ID;
   delete process.env.X_NW_MCR_EXT_VERSION;
+  clearDualInstanceSentinel();
   try {
     fs.rmSync(logPath());
   } catch {
@@ -113,6 +122,7 @@ beforeEach(() => {
 afterEach(() => {
   delete process.env.X_NW_CONVERSATION_ID;
   delete process.env.X_NW_MCR_EXT_VERSION;
+  clearDualInstanceSentinel();
 });
 
 describe("X-NW-Conversation-ID header wiring", () => {
@@ -366,5 +376,264 @@ describe("#4111 in-session branch isolation", () => {
     expect(composed.length).toBeLessThan(256);
     // All printable ASCII — no control chars.
     expect(/^[\x20-\x7E]+$/.test(composed)).toBe(true);
+  });
+});
+
+describe("#44 dual-instance guard", () => {
+  // Pi auto-loads ~/.pi/agent/extensions/neuralwatt-mcr.ts in addition to any
+  // -e <path> copy, so two copies of the module — each with its own module
+  // scope — can be activated in one process. The 2026-06-09 forensics show
+  // exactly that (every log event doubled, 2.3.0 + 2.1.1 both live), with two
+  // drop-protocol state machines racing one session. First activation wins;
+  // the second must register NOTHING and say so loudly.
+
+  it("first activation claims the globalThis sentinel and registers normally", async () => {
+    const pi = makeMockPi();
+    (await loadExtension())(pi);
+
+    expect(pi.providers["neuralwatt"]).toBeTruthy();
+    expect(pi.handlers.size).toBeGreaterThan(0);
+
+    const sentinel = (globalThis as Record<string, unknown>)
+      .__NEURALWATT_MCR_ACTIVE__ as Record<string, unknown>;
+    expect(sentinel).toBeTruthy();
+    expect(sentinel.version).toBe("2.4.0");
+    expect(typeof sentinel.module).toBe("string");
+    expect(typeof sentinel.ts).toBe("string");
+
+    // The wire-visible version (X-NW-MCR-Ext-Version env seed) matches the
+    // bump, so prod can verify the rollout.
+    expect(process.env.X_NW_MCR_EXT_VERSION).toBe("2.4.0");
+  });
+
+  it("second activation in the same process registers NOTHING and logs dual_instance_blocked", async () => {
+    const ext = await loadExtension();
+    const pi1 = makeMockPi();
+    const pi2 = makeMockPi();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      ext(pi1);
+      expect(pi1.providers["neuralwatt"]).toBeTruthy();
+      expect(pi1.handlers.size).toBeGreaterThan(0);
+
+      ext(pi2);
+      // No HTTP hooks, no handlers, no provider — nothing at all.
+      expect(Object.keys(pi2.providers)).toHaveLength(0);
+      expect(pi2.handlers.size).toBe(0);
+
+      // Loud in the extension log…
+      const blockedLine = readLog()
+        .split("\n")
+        .find((l) => l.includes("dual_instance_blocked"));
+      expect(blockedLine).toBeTruthy();
+      const blocked = JSON.parse(blockedLine!);
+      expect(blocked.winner.version).toBe("2.4.0");
+      expect(blocked.loser.version).toBe("2.4.0");
+
+      // …and on stderr (visible interactively).
+      expect(errSpy).toHaveBeenCalled();
+      expect(String(errSpy.mock.calls[0][0])).toContain(
+        "DUAL INSTANCE BLOCKED",
+      );
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("fail-open: a sealed sentinel slot never blocks activation", async () => {
+    // Simulate a hostile/frozen global: the sentinel slot exists but cannot
+    // be written (strict-mode write throws). Activation must still register
+    // everything — a doubly-registered extension is the known-bad state we
+    // survived; a never-registered one is strictly worse — and log the
+    // anomaly.
+    Object.defineProperty(globalThis, "__NEURALWATT_MCR_ACTIVE__", {
+      value: undefined,
+      writable: false,
+      configurable: true, // so the afterEach cleanup can remove it
+    });
+
+    const pi = makeMockPi();
+    (await loadExtension())(pi);
+
+    expect(pi.providers["neuralwatt"]).toBeTruthy();
+    expect(pi.handlers.size).toBeGreaterThan(0);
+    expect(readLog()).toContain("dual_instance_guard_anomaly");
+  });
+});
+
+describe("#44 post-drop stale-window self-heal", () => {
+  // Forensics 2026-06-09: after honoring a server context-drop, the
+  // extension's outbound window froze at a 114-message snapshot for 35-40
+  // minute stretches while 575+ new local turns never went out; the
+  // server-side breaker fired ~24k times into the stale window with zero
+  // effect. The invariant detects "window signature identical to the previous
+  // request WHILE local history grew" and, after N=2 consecutive triggers,
+  // resets the drop bookkeeping and sends the FULL history.
+
+  function makeMCRCtx(sessionId: string) {
+    return {
+      model: { id: "neuralwatt/glm-5.1-long" },
+      sessionManager: { getSessionId: () => sessionId, getBranch: () => [] },
+      ui: { setStatus: () => {} },
+    };
+  }
+
+  // History shape: 3 user anchors early (anchor floor = index 4, so
+  // dropStart = 5), then identical tool turns appended at the tail. Identical
+  // tail messages let a test freeze the window SIGNATURE (length + last-msg
+  // role/content-length) while the history grows, by moving safe_drop_before
+  // in lock-step — the simulated equivalent of whatever swallowed the new
+  // turns in prod.
+  function mkMsgs(n: number): Array<Record<string, unknown>> {
+    const msgs: Array<Record<string, unknown>> = [
+      { type: "user", content: "u1" },
+      { type: "assistant", content: "a1" },
+      { type: "user", content: "u2" },
+      { type: "assistant", content: "a2" },
+      { type: "user", content: "u3" },
+      { type: "assistant", content: "a3" },
+    ];
+    while (msgs.length < n) msgs.push({ type: "tool", content: "tool-result" });
+    return msgs;
+  }
+
+  // Drive the server side of the drop handshake: the gateway confirms it
+  // persisted history (stored_through) and authorizes the client to drop
+  // everything before safe_drop_before.
+  async function serverConfirm(
+    pi: MockPi,
+    ctx: unknown,
+    safeDropBefore: number,
+  ) {
+    await pi.handlers.get("after_provider_response")!(
+      {
+        headers: {
+          "x-mcr-session-fp": "fp-test-4444",
+          "x-mcr-safe-drop-before": String(safeDropBefore),
+          "x-mcr-stored-through": String(safeDropBefore),
+        },
+      },
+      ctx,
+    );
+  }
+
+  it("self-heals after N consecutive frozen-window requests while local history grows", async () => {
+    const pi = makeMockPi();
+    (await loadExtension())(pi);
+    const ctx = makeMCRCtx("sess-heal-1");
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await pi.handlers.get("session_start")!({}, ctx);
+      const context = pi.handlers.get("context")!;
+
+      // Turn 1: server authorizes drop<8; window built normally (baseline).
+      // drop range [5, 8) -> 7 of 10 messages go out.
+      await serverConfirm(pi, ctx, 8);
+      const r1 = await context({ messages: mkMsgs(10) }, ctx);
+      expect(r1.messages).toHaveLength(7);
+
+      // Turn 2: local history grew (11 msgs) but the outgoing window is
+      // shape-identical (same length, same tail) — trigger 1 of 2. Still
+      // drops normally.
+      await serverConfirm(pi, ctx, 9);
+      const r2 = await context({ messages: mkMsgs(11) }, ctx);
+      expect(r2.messages).toHaveLength(7);
+      expect(readLog()).not.toContain("stale_window_self_heal");
+
+      // Turn 3: frozen again while local grew — trigger 2 = N. SELF-HEAL:
+      // no message mutation (the FULL 12-message history goes out), loud log
+      // event + console.error.
+      await serverConfirm(pi, ctx, 10);
+      const r3 = await context({ messages: mkMsgs(12) }, ctx);
+      expect(r3).toBeUndefined();
+
+      const healLine = readLog()
+        .split("\n")
+        .find((l) => l.includes("stale_window_self_heal"));
+      expect(healLine).toBeTruthy();
+      const heal = JSON.parse(healLine!);
+      expect(heal.repeats).toBe(2);
+      expect(heal.window_len).toBe(7);
+      expect(heal.local_len).toBe(12);
+      expect(errSpy).toHaveBeenCalled();
+      expect(String(errSpy.mock.calls[0][0])).toContain(
+        "STALE WINDOW SELF-HEAL",
+      );
+
+      // Post-heal: drop bookkeeping was reset, so the next request also
+      // sends the full history (safe_drop_before is back to 0)…
+      const r4 = await context({ messages: mkMsgs(13) }, ctx);
+      expect(r4).toBeUndefined();
+      const log = readLog();
+      expect(log).toContain("safe_drop_before_zero");
+      // …and the heal does NOT loop: still exactly one heal event.
+      expect(log.match(/stale_window_self_heal/g)).toHaveLength(1);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("false-positive safety: a pure retry (identical window, NO local growth) never triggers", async () => {
+    const pi = makeMockPi();
+    (await loadExtension())(pi);
+    const ctx = makeMCRCtx("sess-retry-1");
+    await pi.handlers.get("session_start")!({}, ctx);
+    const context = pi.handlers.get("context")!;
+    await serverConfirm(pi, ctx, 8);
+
+    // The same 10-message history sent 4 times (e.g. network retries): the
+    // window signature is identical every time but the local history has NOT
+    // grown, so the two-sided trigger stays false and the drop keeps
+    // applying.
+    for (let i = 0; i < 4; i++) {
+      const r = await context({ messages: mkMsgs(10) }, ctx);
+      expect(r.messages).toHaveLength(7);
+    }
+    expect(readLog()).not.toContain("stale_window_self_heal");
+  });
+
+  it("false-positive safety: a normally advancing window never triggers", async () => {
+    const pi = makeMockPi();
+    (await loadExtension())(pi);
+    const ctx = makeMCRCtx("sess-adv-1");
+    await pi.handlers.get("session_start")!({}, ctx);
+    const context = pi.handlers.get("context")!;
+    await serverConfirm(pi, ctx, 8);
+
+    // safe_drop_before stays fixed while the history grows — the healthy
+    // shape: the window's tail carries each new local turn, so the signature
+    // advances every request and the streak never starts.
+    for (let n = 10; n <= 14; n++) {
+      const r = await context({ messages: mkMsgs(n) }, ctx);
+      expect(r.messages).toHaveLength(n - 3); // fixed 3-message drop range
+    }
+    expect(readLog()).not.toContain("stale_window_self_heal");
+  });
+
+  it("a single frozen request followed by an advancing one resets the streak", async () => {
+    const pi = makeMockPi();
+    (await loadExtension())(pi);
+    const ctx = makeMCRCtx("sess-streak-1");
+    await pi.handlers.get("session_start")!({}, ctx);
+    const context = pi.handlers.get("context")!;
+
+    // Baseline (10 msgs, drop<8 -> 7 out), then ONE frozen-while-growing
+    // request (trigger 1 of 2)…
+    await serverConfirm(pi, ctx, 8);
+    await context({ messages: mkMsgs(10) }, ctx);
+    await serverConfirm(pi, ctx, 9);
+    const r2 = await context({ messages: mkMsgs(11) }, ctx);
+    expect(r2.messages).toHaveLength(7);
+
+    // …then the window ADVANCES (same drop<9, history grows -> 8 out): the
+    // consecutive-trigger streak must reset…
+    const r3 = await context({ messages: mkMsgs(12) }, ctx);
+    expect(r3.messages).toHaveLength(8);
+
+    // …so a later single frozen request is trigger 1 again, not 2 — no heal.
+    await serverConfirm(pi, ctx, 10);
+    const r4 = await context({ messages: mkMsgs(13) }, ctx);
+    expect(r4.messages).toHaveLength(8);
+    expect(readLog()).not.toContain("stale_window_self_heal");
   });
 });

--- a/plugins/pi/extensions/neuralwatt-mcr.ts
+++ b/plugins/pi/extensions/neuralwatt-mcr.ts
@@ -30,7 +30,22 @@ import { randomUUID } from "node:crypto";
 //           across siblings (inference_frontend#4111, spiffytech 2026-06-03
 //           report). Now the conv-id becomes ``${sessionId}:${newLeafId}``
 //           on branch nav and stays bare on session boot.
-const EXTENSION_VERSION = "2.3.0";
+//   2.4.0 — dual-instance guard + post-drop stale-window self-heal (tools#44,
+//           forensics 2026-06-09). Pi auto-loads
+//           ~/.pi/agent/extensions/neuralwatt-mcr.ts IN ADDITION to any
+//           ``-e <path>`` copy, so two copies — potentially different
+//           versions — race the same drop-protocol session (observed: every
+//           log event doubled, 2.3.0 + 2.1.1 both live, 3-hour runaway with
+//           the outbound window frozen at a 114-message snapshot while new
+//           local turns never went out). Guard: first activation claims a
+//           process-global sentinel on globalThis; later activations register
+//           nothing and log ``dual_instance_blocked``. Invariant: if the
+//           outgoing post-drop window signature repeats while the local
+//           history grows (STALE_WINDOW_HEAL_REPEATS consecutive requests),
+//           reset the drop bookkeeping and send the FULL history
+//           (``stale_window_self_heal``) so the server re-establishes
+//           stored_through. No wire-format changes otherwise.
+const EXTENSION_VERSION = "2.4.0";
 
 // ── Provider definition (folded in from the former configs/models.json) ─────
 // Declaring the full provider config inline lets this extension be a
@@ -87,6 +102,68 @@ function nwlog(event: string, data: Record<string, unknown> = {}): void {
   }
 }
 
+// ── Dual-instance guard (tools#44) ──────────────────────────────────────────
+// Pi AUTO-LOADS ~/.pi/agent/extensions/neuralwatt-mcr.ts in addition to any
+// `-e <path>` copy, so two copies of this module — potentially DIFFERENT
+// VERSIONS — can be activated in one process. Two drop-protocol state machines
+// racing on the same session produced the 2026-06-09 catastrophic runaway
+// (every extension log event emitted twice, versions 2.3.0 + 2.1.1
+// simultaneously active). First activation wins; any later activation must
+// register nothing and say so loudly.
+//
+// The sentinel MUST live on globalThis, NOT module scope: two module copies
+// loaded from different paths each get their own module scope (exactly what
+// the dual-load evidence shows), so a module-scoped flag can never see the
+// other copy. globalThis is the only scope both copies share.
+const DUAL_INSTANCE_SENTINEL_KEY = "__NEURALWATT_MCR_ACTIVE__";
+
+interface DualInstanceSentinel {
+  version: string;
+  module: string;
+  ts: string;
+}
+
+// Best-effort hint of which file this module copy was loaded from, so the
+// dual_instance_blocked log can tell the auto-loaded copy from the -e one.
+function moduleHint(): string {
+  try {
+    return typeof import.meta?.url === "string" ? import.meta.url : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+// Claim the process-global activation sentinel. Returns the already-active
+// instance's sentinel when another copy won (caller must NOT register), or
+// null when this copy holds the claim and may register normally.
+//
+// Resilience: a frozen/sealed globalThis (or any other exotic environment
+// where the read/write throws) must NEVER break activation — fail OPEN to
+// registering and log the anomaly. A doubly-registered extension is the
+// known-bad state we already survived; a never-registered one is strictly
+// worse (no MCR at all).
+function claimDualInstanceSentinel(): DualInstanceSentinel | null {
+  try {
+    const g = globalThis as unknown as Record<string, unknown>;
+    const existing = g[DUAL_INSTANCE_SENTINEL_KEY];
+    if (existing && typeof existing === "object") {
+      return existing as DualInstanceSentinel;
+    }
+    const sentinel: DualInstanceSentinel = {
+      version: EXTENSION_VERSION,
+      module: moduleHint(),
+      ts: new Date().toISOString(),
+    };
+    g[DUAL_INSTANCE_SENTINEL_KEY] = sentinel;
+    return null;
+  } catch (err) {
+    nwlog("dual_instance_guard_anomaly", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
 interface MCRMetadata {
   session_fp: string;
   stored_through: number;
@@ -114,6 +191,15 @@ interface SessionState {
   contextTokens: number;
   lastMcrMeta: MCRMetadata | null;
   lastEnergy: EnergyData | null;
+  // tools#44 post-drop stale-window invariant bookkeeping. From the previous
+  // drop-applying request: a cheap signature of the outgoing window
+  // (length + last-message identity), the local history length at that
+  // request, and how many CONSECUTIVE requests have tripped the
+  // frozen-while-growing condition. See the invariant block in the
+  // ``context`` handler.
+  prevWindowSig: string | null;
+  prevLocalLen: number;
+  staleWindowRepeats: number;
   // #4111: pi's in-session ``SessionManager.branch()`` (`session-manager.js:913`)
   // reassigns the leaf pointer within the same session file but does NOT
   // change the session id. Without this field we'd send the gateway the
@@ -157,6 +243,9 @@ const state: SessionState = {
   contextTokens: 0,
   lastMcrMeta: null,
   lastEnergy: null,
+  prevWindowSig: null,
+  prevLocalLen: 0,
+  staleWindowRepeats: 0,
   activeBranchLeafId: null,
   inFlightSince: null,
   inFlightTickerHandle: null,
@@ -407,6 +496,53 @@ function resolveConversationId(
   return { id: getUuidFallback(), source: "uuid-fallback" };
 }
 
+// ── Post-drop stale-window invariant (tools#44) ─────────────────────────────
+// After the extension honors a server context-drop, the outgoing window must
+// KEEP ADVANCING as new local turns land. The 2026-06-09 forensics show the
+// opposite: the outbound window froze at a 114-message snapshot for 35-40
+// minute stretches while 575+ new local turns piled up unsent (a fresh 25KB
+// tool result recorded locally was absent from the request sent 42ms later),
+// and the server-side breaker fired ~24k times into the stale window with
+// zero effect. The freeze is not reproduced under a debugger, so this is a
+// HARDENING invariant: detect the failure class at request time and self-heal
+// loudly, rather than point-fix a mechanism we can't observe.
+//
+// Trigger (two-sided, false-positive-safe): the outgoing-window signature is
+// IDENTICAL to the previous request's WHILE the local history has GROWN since
+// that request. A pure retry (identical window, no new local turns) does not
+// trigger; a healthy window advances its tail every turn and never matches.
+// After STALE_WINDOW_HEAL_REPEATS consecutive triggers, reset the drop
+// bookkeeping and send the FULL local history — the server re-establishes
+// stored_through from it. Healing resets the tracking state, so a re-heal
+// needs a fresh freeze (no heal loop). Zero wire-format changes otherwise.
+const STALE_WINDOW_HEAL_REPEATS = 2;
+
+// Cheap identity signature of an outgoing message window: window length plus
+// role and content length of the LAST message. Deliberately not a full hash —
+// the invariant only needs "did the window visibly advance?", and a healthy
+// post-drop window keeps its newest local message at the tail, so any new
+// turn flips the signature.
+function windowSignature(msgs: Array<unknown>): string {
+  if (msgs.length === 0) return "0";
+  const last = msgs[msgs.length - 1] as {
+    role?: unknown;
+    type?: unknown;
+    content?: unknown;
+  };
+  const role = String(last?.role ?? last?.type ?? "?");
+  let contentLen = -1;
+  try {
+    const content = last?.content;
+    contentLen =
+      typeof content === "string"
+        ? content.length
+        : JSON.stringify(content ?? null).length;
+  } catch {
+    // unserializable content — keep -1; still a stable marker for "same shape"
+  }
+  return `${msgs.length}:${role}:${contentLen}`;
+}
+
 function computeDropRange(
   entries: Array<{ role?: string; type?: string }>,
   safeDropBefore: number,
@@ -421,6 +557,29 @@ function computeDropRange(
 }
 
 export default function (pi: ExtensionAPI) {
+  // ── Dual-instance guard (tools#44): first activation wins ──
+  // Claim the process-global sentinel BEFORE registering anything (provider,
+  // handlers, env seeds). If another copy of this extension already activated
+  // in this process — pi auto-loads ~/.pi/agent/extensions/neuralwatt-mcr.ts
+  // in addition to any `-e <path>` copy — register NOTHING: a second
+  // drop-protocol state machine racing the first on the same session is the
+  // proven mechanism behind the 2026-06-09 runaway. Log loudly to both the
+  // extension log (greppable forensics) and stderr (visible interactively).
+  const activeInstance = claimDualInstanceSentinel();
+  if (activeInstance) {
+    const loser = { version: EXTENSION_VERSION, module: moduleHint() };
+    nwlog("dual_instance_blocked", { winner: activeInstance, loser });
+    console.error(
+      `[neuralwatt-mcr] DUAL INSTANCE BLOCKED: extension v${loser.version} ` +
+        `(${loser.module}) did NOT register — v${activeInstance.version} ` +
+        `(${activeInstance.module}) is already active in this process. ` +
+        `Pi auto-loads ~/.pi/agent/extensions/neuralwatt-mcr.ts in addition ` +
+        `to any -e <path> copy; remove the duplicate so only one copy loads ` +
+        `(see neuralwatt-tools#44).`,
+    );
+    return;
+  }
+
   const MCR_STATUS_KEY = "nw-mcr";
   const ENERGY_STATUS_KEY = "nw-energy";
 
@@ -650,6 +809,9 @@ export default function (pi: ExtensionAPI) {
     state.contextTokens = 0;
     state.lastMcrMeta = null;
     state.lastEnergy = null;
+    state.prevWindowSig = null;
+    state.prevLocalLen = 0;
+    state.staleWindowRepeats = 0;
     state.inFlightSince = null;
     if (state.inFlightTickerHandle !== null) {
       clearInterval(state.inFlightTickerHandle);
@@ -862,6 +1024,57 @@ export default function (pi: ExtensionAPI) {
       return;
     }
 
+    // ── Post-drop stale-window invariant (tools#44) ──
+    // The window we are about to send must keep advancing as new local turns
+    // land. Two-sided trigger: signature identical to the PREVIOUS request's
+    // outgoing window WHILE the local history has grown since that request.
+    // A pure retry (no local growth) resets the streak; a healthy window's
+    // tail carries the newest local message, so growth flips the signature.
+    const windowSig = windowSignature(filtered);
+    const localLen = event.messages.length;
+    const frozenWhileGrowing =
+      state.prevWindowSig !== null &&
+      windowSig === state.prevWindowSig &&
+      localLen > state.prevLocalLen;
+    state.staleWindowRepeats = frozenWhileGrowing
+      ? state.staleWindowRepeats + 1
+      : 0;
+
+    if (state.staleWindowRepeats >= STALE_WINDOW_HEAL_REPEATS) {
+      // SELF-HEAL: the outgoing window is provably stale (frozen for
+      // STALE_WINDOW_HEAL_REPEATS consecutive requests while local history
+      // grew). Reset the drop bookkeeping and send the FULL local history on
+      // this request — the server re-establishes stored_through /
+      // safe_drop_before from it via the normal response headers. Tracking
+      // state resets too, so the next heal needs a fresh freeze (no loop).
+      nwlog("stale_window_self_heal", {
+        repeats: state.staleWindowRepeats,
+        window_len: filtered.length,
+        local_len: localLen,
+        safe_drop_before: state.safeDropBefore,
+        session_fp: state.sessionFp,
+      });
+      console.error(
+        `[neuralwatt-mcr] STALE WINDOW SELF-HEAL: outgoing window frozen at ` +
+          `${filtered.length} msgs across ${state.staleWindowRepeats} ` +
+          `consecutive requests while local history grew to ${localLen} — ` +
+          `resetting drop bookkeeping and sending the full history so the ` +
+          `server re-establishes stored_through (neuralwatt-tools#44).`,
+      );
+      state.safeDropBefore = 0;
+      state.storedThrough = 0;
+      state.lastMcrMeta = null;
+      state.prevWindowSig = null;
+      state.prevLocalLen = 0;
+      state.staleWindowRepeats = 0;
+      updateStatusBar(ctx);
+      // No message mutation — the full local history goes out on this request.
+      return;
+    }
+
+    state.prevWindowSig = windowSig;
+    state.prevLocalLen = localLen;
+
     nwlog("context_drop", {
       drop_start: dropStart,
       drop_end: clampedEnd,
@@ -991,6 +1204,9 @@ export default function (pi: ExtensionAPI) {
     state.contextTokens = 0;
     state.lastMcrMeta = null;
     state.lastEnergy = null;
+    state.prevWindowSig = null;
+    state.prevLocalLen = 0;
+    state.staleWindowRepeats = 0;
 
     // #4111: pin the active branch's leaf id so the wire-side
     // X-NW-Conversation-ID becomes ``${sessionId}:${newLeafId}`` for this


### PR DESCRIPTION
## Forensic summary (issue #44, 2026-06-09)

A prod canary session suffered a 3-hour catastrophic runaway. After the extension honored a server context-drop at 14:58:48, its **outbound window froze at a 114-message snapshot** for 35-40-minute stretches. New local turns (575+ file re-reads) never went out — a fresh 25KB tool result recorded locally at 16:41:14.878 was **absent from the request sent 42ms later**. The full history escaped exactly once per user prompt, and the server-side breaker fired ~24k times into the stale window with zero effect.

**Proven mechanism for the dual-load (leading suspect for the freeze):** pi auto-loads `~/.pi/agent/extensions/neuralwatt-mcr.ts` *in addition to* any `-e <path>` copy. Every extension log event was emitted **twice**, with versions **2.3.0 and 2.1.1 simultaneously active** — two different-version drop-protocol state machines racing on the same session.

**Honest caveat:** the freeze itself was not reproduced under a debugger. This PR is therefore *hardening*, not a speculative point-fix: it makes the failure class impossible (guard) or loud + self-healing (invariant).

## What this PR does

### 1. Dual-instance guard
At activation, the extension claims a process-global sentinel on **`globalThis`** (`__NEURALWATT_MCR_ACTIVE__` = `{version, module, ts}`) — deliberately *not* module scope, since two module copies loaded from different paths each get their own module scope (exactly what the dual-load evidence shows). First activation wins and registers normally. A later activation **registers nothing** (no HTTP hooks, no handlers) and logs loudly to both the extension log (`{"event":"dual_instance_blocked", winner, loser}`) and `console.error`. The guard is resilient: a frozen/sealed `globalThis` can never break activation — it fails *open* to registering and logs the anomaly.

### 2. Post-drop window-advance invariant + self-heal
On each drop-applying request the extension tracks (a) a cheap signature of the outgoing window (length + last-message role/content-length) and (b) the local history length from the previous request. **Trigger:** the outgoing-window signature is *identical* to the previous request's **while** the local history has *grown* since that request. After **2 consecutive** triggers, it self-heals: resets the drop bookkeeping (`safe_drop_before` / `stored_through`) and sends the **full local history** on this request — the server re-establishes `stored_through` from it via the normal response headers — and emits `{"event":"stale_window_self_heal", repeats, window_len, local_len}` + `console.error`. Healing resets the tracking state, so the next heal needs a fresh freeze (no heal loop). **Zero wire-format changes otherwise.**

### False-positive safety
The trigger is two-sided: a pure retry (identical window, **no** new local turns) never trips it; a healthy post-drop window keeps the newest local message at its tail, so any new turn flips the signature and never matches. Both cases are covered by dedicated tests, plus a streak-reset test (one frozen request followed by an advancing one resets the counter).

### Version bump
`EXTENSION_VERSION` 2.3.0 → **2.4.0**. It's sent as `X-NW-MCR-Ext-Version` on every request, so prod can verify the rollout (e.g. the ext-version capture from inference_frontend#4051/#4065).

## Test plan

- `npm test` (vitest) in `plugins/pi`: **20/20 green** (13 existing + 7 new)
  - guard: second activation in one process registers nothing + emits `dual_instance_blocked`; sealed-sentinel fail-open
  - invariant: frozen window + growing local history → self-heal fires at N=2, full history sent, state resets (no re-heal loop)
  - false-positive safety: pure retry never triggers; advancing window never triggers; single-trigger streak resets
- No typecheck/lint script exists in this package; vitest's esbuild transform is the compile gate.

Addresses #44 (intentionally not auto-closing — ask 3, the server-side resync signal, remains open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
