### PR TITLE
chore(pi-ext): bump package version to 2.4.0 for publish

### DIFF
--- a/plugins/pi/package.json
+++ b/plugins/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neuralwatt/pi-mcr-extension",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Neuralwatt MCR extension for Pi — 1M virtual context via server-side compaction",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
One-line version bump aligning `package.json` with `EXTENSION_VERSION 2.4.0` (#45 — dual-instance guard + stale-window self-heal), so `npm publish` ships the fix to `npm:@neuralwatt/pi-mcr-extension` consumers. Publish is manual after merge (no publish workflow in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)