### PR TITLE
feat(pi-ext): register mcr_lookup placeholder stub (2.5.0)

### DIFF
--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -177,7 +177,7 @@ After:  [anchor1, anchor2, anchor3, recent_36, ..., recent_85]
 2. The MCR pipeline compacts old context server-side.
 3. Response headers include `X-MCR-Safe-Drop-Before: 35`.
 4. On the next `context` event (before the next LLM call), the extension drops messages 4–35.
-5. If the model needs anything from a dropped range, it can call the `mcr_lookup` tool and the server retrieves it from its store.
+5. If the model needs anything from a dropped range, it can call the `mcr_lookup` tool and the server retrieves it from its store. On mixed agentic turns the gateway forwards that tool call to the client by design, so the extension (2.5.0) registers a local `mcr_lookup` stub that returns a short placeholder — the gateway replaces it with the real recalled content on the next request ("cross-turn injection", inference_frontend#4039). The stub never resolves anything itself; without it, pi rendered a harmless-but-alarming "Tool mcr_lookup not found" error in the transcript.
 
 ## MCR vs non-MCR models
 

--- a/plugins/pi/extensions/neuralwatt-mcr.test.ts
+++ b/plugins/pi/extensions/neuralwatt-mcr.test.ts
@@ -24,16 +24,20 @@ type Handler = (event: any, ctx: any) => any;
 interface MockPi {
   handlers: Map<string, Handler>;
   providers: Record<string, any>;
+  tools: Record<string, any>;
   on: (event: string, handler: Handler) => void;
   registerProvider: (name: string, config: any) => void;
+  registerTool: (tool: any) => void;
 }
 
 function makeMockPi(): MockPi {
   const handlers = new Map<string, Handler>();
   const providers: Record<string, any> = {};
+  const tools: Record<string, any> = {};
   return {
     handlers,
     providers,
+    tools,
     on(event, handler) {
       // The extension registers some events more than once across refactors;
       // last-registration-wins mirrors how Pi's runner would dispatch the
@@ -42,6 +46,9 @@ function makeMockPi(): MockPi {
     },
     registerProvider(name, config) {
       providers[name] = config;
+    },
+    registerTool(tool) {
+      tools[tool.name] = tool;
     },
   };
 }
@@ -397,13 +404,13 @@ describe("#44 dual-instance guard", () => {
     const sentinel = (globalThis as Record<string, unknown>)
       .__NEURALWATT_MCR_ACTIVE__ as Record<string, unknown>;
     expect(sentinel).toBeTruthy();
-    expect(sentinel.version).toBe("2.4.0");
+    expect(sentinel.version).toBe("2.5.0");
     expect(typeof sentinel.module).toBe("string");
     expect(typeof sentinel.ts).toBe("string");
 
     // The wire-visible version (X-NW-MCR-Ext-Version env seed) matches the
     // bump, so prod can verify the rollout.
-    expect(process.env.X_NW_MCR_EXT_VERSION).toBe("2.4.0");
+    expect(process.env.X_NW_MCR_EXT_VERSION).toBe("2.5.0");
   });
 
   it("second activation in the same process registers NOTHING and logs dual_instance_blocked", async () => {
@@ -417,9 +424,10 @@ describe("#44 dual-instance guard", () => {
       expect(pi1.handlers.size).toBeGreaterThan(0);
 
       ext(pi2);
-      // No HTTP hooks, no handlers, no provider — nothing at all.
+      // No HTTP hooks, no handlers, no provider, no tools — nothing at all.
       expect(Object.keys(pi2.providers)).toHaveLength(0);
       expect(pi2.handlers.size).toBe(0);
+      expect(Object.keys(pi2.tools)).toHaveLength(0);
 
       // Loud in the extension log…
       const blockedLine = readLog()
@@ -427,8 +435,8 @@ describe("#44 dual-instance guard", () => {
         .find((l) => l.includes("dual_instance_blocked"));
       expect(blockedLine).toBeTruthy();
       const blocked = JSON.parse(blockedLine!);
-      expect(blocked.winner.version).toBe("2.4.0");
-      expect(blocked.loser.version).toBe("2.4.0");
+      expect(blocked.winner.version).toBe("2.5.0");
+      expect(blocked.loser.version).toBe("2.5.0");
 
       // …and on stderr (visible interactively).
       expect(errSpy).toHaveBeenCalled();
@@ -635,5 +643,67 @@ describe("#44 post-drop stale-window self-heal", () => {
     const r4 = await context({ messages: mkMsgs(13) }, ctx);
     expect(r4.messages).toHaveLength(8);
     expect(readLog()).not.toContain("stale_window_self_heal");
+  });
+});
+
+describe("mcr_lookup placeholder stub (inference_frontend#4039)", () => {
+  // On mixed agentic turns the gateway forwards the model's server-side
+  // `mcr_lookup` tool call to the client by design; the gateway replaces the
+  // client's placeholder tool_result with the real content on the NEXT
+  // request (cross-turn injection). The stub exists only so pi stops
+  // rendering "Tool mcr_lookup not found" — it must return a stable
+  // placeholder and must NEVER resolve the hash itself (client protocol
+  // forbids client-side resolution).
+  const PLACEHOLDER =
+    "[recall delegated to server — content is injected by the gateway on the next turn]";
+
+  it("registers an mcr_lookup tool with a required string `hash` param", async () => {
+    const pi = makeMockPi();
+    (await loadExtension())(pi);
+
+    const tool = pi.tools["mcr_lookup"];
+    expect(tool).toBeTruthy();
+    expect(tool.label).toBe("MCR server-side recall");
+    // Single required string param named `hash`, matching the gateway's tool
+    // definition so the forwarded call passes client-side validation.
+    expect(tool.parameters.required).toEqual(["hash"]);
+    expect(tool.parameters.properties.hash.type).toBe("string");
+    // Extra params from a future gateway revision must NOT fail validation.
+    expect(tool.parameters.additionalProperties).not.toBe(false);
+  });
+
+  it("execute returns the neutral placeholder and does not resolve the hash", async () => {
+    const pi = makeMockPi();
+    (await loadExtension())(pi);
+
+    const tool = pi.tools["mcr_lookup"];
+    const result = await tool.execute("call_1", { hash: "abc123def456" });
+
+    // PLACEHOLDER ONLY — the gateway overwrites it via cross-turn injection.
+    expect(result.content).toEqual([{ type: "text", text: PLACEHOLDER }]);
+    expect(result.details).toEqual({ hash: "abc123def456", placeholder: true });
+
+    // Observable in the extension log for forensics.
+    const line = readLog()
+      .split("\n")
+      .find((l) => l.includes("mcr_lookup_stub"));
+    expect(line).toBeTruthy();
+    expect(JSON.parse(line!).hash_prefix).toBe("abc123def456".slice(0, 12));
+  });
+
+  it("prepareArguments coerces a missing/non-string hash and drops extra params", async () => {
+    const pi = makeMockPi();
+    (await loadExtension())(pi);
+
+    const tool = pi.tools["mcr_lookup"];
+    // Extra params are ignored, hash passes through.
+    expect(tool.prepareArguments({ hash: "h1", surprise: 42 })).toEqual({
+      hash: "h1",
+    });
+    // Defensive coercions — never let client-side validation reject a call
+    // the gateway will resolve anyway.
+    expect(tool.prepareArguments({})).toEqual({ hash: "" });
+    expect(tool.prepareArguments(undefined)).toEqual({ hash: "" });
+    expect(tool.prepareArguments({ hash: 123 })).toEqual({ hash: "123" });
   });
 });

--- a/plugins/pi/extensions/neuralwatt-mcr.ts
+++ b/plugins/pi/extensions/neuralwatt-mcr.ts
@@ -1,4 +1,9 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+// `typebox` is aliased by pi's extension loader (jiti) to the bundled copy at
+// runtime, so this single-file extension stays dependency-free when installed
+// via `pi install npm:@neuralwatt/pi-mcr-extension`. For `vitest` it resolves
+// from this package's devDependencies.
+import { Type } from "typebox";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
@@ -45,7 +50,20 @@ import { randomUUID } from "node:crypto";
 //           reset the drop bookkeeping and send the FULL history
 //           (``stale_window_self_heal``) so the server re-establishes
 //           stored_through. No wire-format changes otherwise.
-const EXTENSION_VERSION = "2.4.0";
+//   2.5.0 — register a local `mcr_lookup` placeholder stub
+//           (inference_frontend#4039). On mixed agentic turns the gateway
+//           forwards the model's server-side `mcr_lookup` tool call to the
+//           client by design (the gateway resolves the hash itself and
+//           replaces the client's placeholder tool_result with the real
+//           content on the NEXT request — cross-turn injection). Pi had no
+//           such tool registered, so it errored locally and rendered
+//           "Tool mcr_lookup not found" in the transcript — alarming but
+//           benign (prod gateway logs show every placeholder replaced and
+//           the model consuming the recalled content). The stub returns a
+//           short neutral placeholder and never resolves the hash; this is
+//           purely cosmetic — the gateway repairs the conversation either
+//           way.
+const EXTENSION_VERSION = "2.5.0";
 
 // ── Provider definition (folded in from the former configs/models.json) ─────
 // Declaring the full provider config inline lets this extension be a
@@ -543,6 +561,40 @@ function windowSignature(msgs: Array<unknown>): string {
   return `${msgs.length}:${role}:${contentLen}`;
 }
 
+// ── mcr_lookup placeholder stub (inference_frontend#4039) ───────────────────
+// On MCR (`-long`) aliases the gateway advertises a server-side recall tool
+// named `mcr_lookup`. On mixed agentic turns the model's `mcr_lookup`
+// tool_call is forwarded to the client verbatim BY DESIGN: the gateway
+// resolves the hash server-side, caches the content, and on the NEXT request
+// replaces the client's placeholder tool_result with the real recalled
+// content ("cross-turn injection", inference_frontend#4039). Pi has no such
+// tool, so without this stub it errors locally and renders
+// "Tool mcr_lookup not found" in the transcript — alarming but benign.
+//
+// The stub must NEVER try to resolve the hash itself: the public client
+// protocol spec (neuralwatt-tools docs, mcr-context-drop-client-protocol)
+// forbids client-side resolution — recall is the gateway's job. It returns
+// this PLACEHOLDER, which the gateway overwrites via cross-turn injection on
+// the next request. Keep the text short and stable: it may transiently reach
+// the model if injection misses a turn, so it must not look like real
+// recalled content and should hint that the content arrives next turn.
+const MCR_LOOKUP_PLACEHOLDER =
+  "[recall delegated to server — content is injected by the gateway on the next turn]";
+
+const MCR_LOOKUP_PARAMS = Type.Object(
+  {
+    // Single required param, matching the gateway's tool definition so the
+    // forwarded call passes client-side validation.
+    hash: Type.String({
+      description:
+        "Content hash of the compacted range to recall (resolved by the gateway, not the client).",
+    }),
+  },
+  // Defensive: the gateway owns this tool's schema. Tolerate any extra
+  // params a future gateway revision may add instead of failing validation.
+  { additionalProperties: true },
+);
+
 function computeDropRange(
   entries: Array<{ role?: string; type?: string }>,
   safeDropBefore: number,
@@ -638,6 +690,43 @@ export default function (pi: ExtensionAPI) {
       "X-NW-MCR-Ext-Version": EXT_VERSION_ENV,
     },
     models: NEURALWATT_MODELS.map((m) => ({ ...m, compat: NEURALWATT_COMPAT })),
+  });
+
+  // ── mcr_lookup placeholder stub (inference_frontend#4039) ──
+  // See the MCR_LOOKUP_PLACEHOLDER block above for the full design note.
+  // Registering the tool keeps pi's tool loop from erroring with
+  // "Tool mcr_lookup not found" when the gateway forwards the model's
+  // server-side recall call; the placeholder result is replaced by the
+  // gateway on the next request (cross-turn injection). This stub must not —
+  // and does not — attempt to resolve the hash.
+  pi.registerTool({
+    name: "mcr_lookup",
+    label: "MCR server-side recall",
+    description:
+      "Server-side recall of MCR-compacted conversation content. The Neuralwatt " +
+      "gateway resolves this tool itself; this local stub only returns a " +
+      "placeholder that the gateway replaces on the next turn. Only meaningful " +
+      "on Neuralwatt MCR (-long) models — never call it directly.",
+    parameters: MCR_LOOKUP_PARAMS,
+    // Defensive shim: never let client-side schema validation reject a call
+    // the gateway will resolve anyway. Coerce `hash` to a string and ignore
+    // any extra params.
+    prepareArguments(args: unknown) {
+      const raw = (args ?? {}) as Record<string, unknown>;
+      return {
+        hash: typeof raw.hash === "string" ? raw.hash : String(raw.hash ?? ""),
+      };
+    },
+    async execute(_toolCallId, params) {
+      nwlog("mcr_lookup_stub", {
+        hash_prefix: String(params.hash).slice(0, 12),
+      });
+      return {
+        // PLACEHOLDER ONLY — overwritten server-side via cross-turn injection.
+        content: [{ type: "text", text: MCR_LOOKUP_PLACEHOLDER }],
+        details: { hash: params.hash, placeholder: true },
+      };
+    },
   });
 
   function updateStatusBar(ctx: ExtensionContext) {

--- a/plugins/pi/package-lock.json
+++ b/plugins/pi/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@neuralwatt/pi-mcr-extension",
-  "version": "2.3.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neuralwatt/pi-mcr-extension",
-      "version": "2.3.0",
+      "version": "2.5.0",
       "license": "MIT",
       "devDependencies": {
+        "typebox": "^1.1.38",
         "vitest": "^2.1.0"
       }
     },
@@ -1290,6 +1291,13 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/typebox": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.2.8.tgz",
+      "integrity": "sha512-rlsKhsd7L3082m9nxhFIB4Gl8jizLd/6YlFAWaz96hdV8+VJRjwYaYmDlT0jlTRwkb48SxCSSirqUtrg/HilNw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/plugins/pi/package.json
+++ b/plugins/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neuralwatt/pi-mcr-extension",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Neuralwatt MCR extension for Pi — 1M virtual context via server-side compaction",
   "type": "module",
   "license": "MIT",
@@ -30,6 +30,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
+    "typebox": "^1.1.38",
     "vitest": "^2.1.0"
   }
 }


### PR DESCRIPTION
## Summary

Dogfooder report (with screenshots, 2026-06-10): pi transcripts on `-long` models show an alarming **"Tool mcr_lookup not found"** error. This is cosmetic, not a malfunction — but it looks like one, so this PR makes pi stop erroring.

**Why it happens (the #4039 cross-turn design).** The gateway's MCR pipeline advertises a server-side recall tool `mcr_lookup` on `-long` aliases. On mixed agentic turns the model's `mcr_lookup` tool_call is forwarded to the client **verbatim, by design** (neuralwatt/inference_frontend#4039): the gateway resolves the hash server-side, caches the content, and on the NEXT request replaces the client's placeholder tool_result with the real recalled content ("cross-turn injection"). Pi has no `mcr_lookup` registered, so its tool loop errors locally and renders the scary message.

**Prod verification that this is UX-only:** gateway logs show the cross-turn injection working — every placeholder tool_result replaced (10/10 resolved + injected) and the model consuming the recalled content on the following turn. The conversation is repaired server-side either way; only the client transcript looks broken.

**Fix:** register a local `mcr_lookup` stub via `pi.registerTool` that immediately returns a short, neutral placeholder:

> `[recall delegated to server — content is injected by the gateway on the next turn]`

The stub **never resolves the hash** — the public client protocol spec forbids client-side resolution; recall is the gateway's job. The placeholder is deliberately short/stable and clearly not real recalled content, since it can transiently reach the model if injection ever misses a turn.

Details:
- Schema matches the gateway's tool def: single required string param `hash`; extra params are tolerated (`additionalProperties: true`) and ignored via a defensive `prepareArguments` shim, so client-side validation can never reject a call the gateway will resolve anyway.
- Friendly UI label: "MCR server-side recall".
- Each stub invocation logs `mcr_lookup_stub` (hash prefix only) to the extension log for forensics.
- `EXTENSION_VERSION` → **2.5.0** (+ package.json/lockfile), version-history comment updated.
- `typebox` added as a **devDependency for vitest only** — at pi runtime the extension loader (jiti) aliases `typebox` to pi's bundled copy, so the published single-file package stays dependency-free.
- README: one-sentence note on the stub in the protocol walkthrough.

**Protocol spec refinement (separate commit on PR #41's branch):** the client protocol spec's blanket "do not execute `mcr_lookup` yourself" is being refined to "must not client-*RESOLVE*": clients MAY register a placeholder stub exactly like this one (the placeholder is replaced server-side by cross-turn injection). Pushed to `docs/mcr-protocol-v2` since the spec doc only exists on that open PR.

**npm publish (2.5.0) happens after merge, by the operator.** Do not publish from this PR.

## Test plan

- [x] `npm test` (vitest): 23/23 pass — 3 new tests cover the stub's registration (name/label/required `hash` string param/extra-params tolerated), the placeholder return shape (+ forensics log line), and the `prepareArguments` coercions; dual-instance guard test extended to assert the second activation registers no tools.
- [x] Ad-hoc `tsc --noEmit` against the real pi typings (`@earendil-works/pi-coding-agent` 0.73.x global install): **no new type errors** — the 3 reported errors are pre-existing on `main` (verified by checking HEAD's file with the same config). The repo has no committed tsc setup; types are erased by jiti at runtime.
- [ ] Not verified without a live pi session: end-to-end behavior when the gateway forwards a real `mcr_lookup` call (stub result rendered, then replaced next turn), and whether the client now ALSO advertising `mcr_lookup` in its tools array interacts cleanly with the gateway's own injected tool def (gateway is expected to own/dedupe it — worth one dogfood session before npm publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)