### PR TITLE
fix(pi-ext): dual-instance guard — release stale sentinel, stop permanent lockout (2.5.1)

### DIFF
--- a/plugins/pi/extensions/neuralwatt-mcr.test.ts
+++ b/plugins/pi/extensions/neuralwatt-mcr.test.ts
@@ -404,13 +404,17 @@ describe("#44 dual-instance guard", () => {
     const sentinel = (globalThis as Record<string, unknown>)
       .__NEURALWATT_MCR_ACTIVE__ as Record<string, unknown>;
     expect(sentinel).toBeTruthy();
-    expect(sentinel.version).toBe("2.5.0");
+    expect(sentinel.version).toBe("2.5.1");
     expect(typeof sentinel.module).toBe("string");
     expect(typeof sentinel.ts).toBe("string");
+    // 2.5.1: the claim carries an activation id (ownership for touch/release)
+    // and a heartbeat (staleness detection).
+    expect(typeof sentinel.activationId).toBe("string");
+    expect(typeof sentinel.heartbeatTs).toBe("number");
 
     // The wire-visible version (X-NW-MCR-Ext-Version env seed) matches the
     // bump, so prod can verify the rollout.
-    expect(process.env.X_NW_MCR_EXT_VERSION).toBe("2.5.0");
+    expect(process.env.X_NW_MCR_EXT_VERSION).toBe("2.5.1");
   });
 
   it("second activation in the same process registers NOTHING and logs dual_instance_blocked", async () => {
@@ -435,8 +439,8 @@ describe("#44 dual-instance guard", () => {
         .find((l) => l.includes("dual_instance_blocked"));
       expect(blockedLine).toBeTruthy();
       const blocked = JSON.parse(blockedLine!);
-      expect(blocked.winner.version).toBe("2.5.0");
-      expect(blocked.loser.version).toBe("2.5.0");
+      expect(blocked.winner.version).toBe("2.5.1");
+      expect(blocked.loser.version).toBe("2.5.1");
 
       // …and on stderr (visible interactively).
       expect(errSpy).toHaveBeenCalled();
@@ -466,6 +470,179 @@ describe("#44 dual-instance guard", () => {
     expect(pi.providers["neuralwatt"]).toBeTruthy();
     expect(pi.handlers.size).toBeGreaterThan(0);
     expect(readLog()).toContain("dual_instance_guard_anomaly");
+  });
+});
+
+describe("2.5.1 dual-instance guard: stale-sentinel release (Nico false positive)", () => {
+  // Pi re-runs every extension factory IN-PROCESS on /new, /resume, fork and
+  // /reload (AgentSessionRuntime.teardownCurrent / AgentSession.reload →
+  // resourceLoader.reload() → loadExtensions; jiti moduleCache:false). The
+  // 2.5.0 sentinel was never cleared, so every such re-activation was blocked
+  // as a "dual instance" while pi had already discarded the prior
+  // activation's handlers — leaving ZERO registered copies (MCR + provider
+  // silently off). The fix releases the claim on session_shutdown and, as a
+  // backup, lets a claimant steal a sentinel whose heartbeat has gone stale.
+
+  function sentinel(): Record<string, unknown> {
+    return (globalThis as Record<string, unknown>)
+      .__NEURALWATT_MCR_ACTIVE__ as Record<string, unknown>;
+  }
+
+  it("session_shutdown releases the claim so the next activation registers (pi /new, /resume, fork, /reload)", async () => {
+    const ext = await loadExtension();
+    const pi1 = makeMockPi();
+    ext(pi1);
+    expect(sentinel()).toBeTruthy();
+
+    // Pi emits session_shutdown to the old runner before every teardown
+    // that precedes an in-process re-load.
+    await pi1.handlers.get("session_shutdown")!(
+      { reason: "new" },
+      makeCtx("neuralwatt/glm-5.1-long"),
+    );
+    expect(sentinel()).toBeUndefined();
+
+    // The re-activation (fresh load pass) must register everything.
+    const pi2 = makeMockPi();
+    ext(pi2);
+    expect(pi2.providers["neuralwatt"]).toBeTruthy();
+    expect(pi2.handlers.size).toBeGreaterThan(0);
+    expect(readLog()).not.toContain("dual_instance_blocked");
+  });
+
+  it("a claimant steals a sentinel whose heartbeat went stale and logs dual_instance_steal_stale", async () => {
+    const ext = await loadExtension();
+    const pi1 = makeMockPi();
+    ext(pi1);
+    const firstActivationId = sentinel().activationId;
+
+    // Simulate a prior activation pi tore down WITHOUT emitting
+    // session_shutdown (e.g. SDK hosts calling resourceLoader.reload()
+    // directly): the claim is still there but its heartbeat has gone stale.
+    sentinel().heartbeatTs = Date.now() - 31_000;
+
+    const pi2 = makeMockPi();
+    ext(pi2);
+    // The new activation registered normally…
+    expect(pi2.providers["neuralwatt"]).toBeTruthy();
+    expect(pi2.handlers.size).toBeGreaterThan(0);
+    // …took over the claim under a new activation id with a fresh heartbeat…
+    expect(sentinel().activationId).not.toBe(firstActivationId);
+    expect(Date.now() - (sentinel().heartbeatTs as number)).toBeLessThan(
+      1_000,
+    );
+    // …and the steal is logged distinctly (NOT as a block).
+    const stealLine = readLog()
+      .split("\n")
+      .find((l) => l.includes("dual_instance_steal_stale"));
+    expect(stealLine).toBeTruthy();
+    const steal = JSON.parse(stealLine!);
+    expect(steal.prior.heartbeat_age_ms).toBeGreaterThan(30_000);
+    expect(steal.claimant.version).toBe("2.5.1");
+    expect(readLog()).not.toContain("dual_instance_blocked");
+  });
+
+  it("a FRESH heartbeat still blocks — true dual-load (auto-load + -e) stays dead", async () => {
+    const ext = await loadExtension();
+    const pi1 = makeMockPi();
+    const pi2 = makeMockPi();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      ext(pi1);
+      // Two copies in one load pass activate within milliseconds — the
+      // second always sees a fresh heartbeat and must register NOTHING.
+      ext(pi2);
+      expect(Object.keys(pi2.providers)).toHaveLength(0);
+      expect(pi2.handlers.size).toBe(0);
+      expect(readLog()).toContain("dual_instance_blocked");
+      expect(readLog()).not.toContain("dual_instance_steal_stale");
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("the winner's heartbeat refreshes on every event it handles", async () => {
+    const pi = makeMockPi();
+    (await loadExtension())(pi);
+
+    // Age the heartbeat, then drive a handled event (any model — the touch
+    // happens before the isMCRModel guard). The heartbeat must come back
+    // fresh, so an ACTIVE copy can never be mistaken for a stale one.
+    sentinel().heartbeatTs = 1;
+    await pi.handlers.get("context")!(
+      { messages: [{ type: "user" }] },
+      makeCtx("deepseek-v4-pro"),
+    );
+    expect(Date.now() - (sentinel().heartbeatTs as number)).toBeLessThan(
+      1_000,
+    );
+
+    // before_provider_request — the per-request hook — touches too.
+    sentinel().heartbeatTs = 1;
+    await pi.handlers.get("before_provider_request")!(
+      { payload: {} },
+      makeCtx("deepseek-v4-pro"),
+    );
+    expect(Date.now() - (sentinel().heartbeatTs as number)).toBeLessThan(
+      1_000,
+    );
+  });
+
+  it("a superseded activation's late session_shutdown cannot release the new holder's claim", async () => {
+    const ext = await loadExtension();
+    const pi1 = makeMockPi();
+    ext(pi1);
+    sentinel().heartbeatTs = Date.now() - 31_000;
+    const pi2 = makeMockPi();
+    ext(pi2); // steals
+    const holderActivationId = sentinel().activationId;
+
+    // The old runner's shutdown fires late — ownership check must no-op.
+    await pi1.handlers.get("session_shutdown")!(
+      { reason: "new" },
+      makeCtx("neuralwatt/glm-5.1-long"),
+    );
+    expect(sentinel()).toBeTruthy();
+    expect(sentinel().activationId).toBe(holderActivationId);
+  });
+
+  it("a legacy (≤2.5.0) sentinel without a heartbeat is never stolen", async () => {
+    // A 2.5.0 winner never refreshes a heartbeat, so staleness cannot be
+    // distinguished from liveness — and a mixed-version install is exactly
+    // the tools#44 dual-load. Block, as before.
+    (globalThis as Record<string, unknown>).__NEURALWATT_MCR_ACTIVE__ = {
+      version: "2.5.0",
+      module: "file:///legacy/neuralwatt-mcr.ts",
+      ts: new Date(Date.now() - 3_600_000).toISOString(),
+    };
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const pi = makeMockPi();
+      (await loadExtension())(pi);
+      expect(Object.keys(pi.providers)).toHaveLength(0);
+      expect(pi.handlers.size).toBe(0);
+      expect(readLog()).toContain("dual_instance_blocked");
+      expect(readLog()).not.toContain("dual_instance_steal_stale");
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("the blocked-copy stderr message carries the false-positive guidance", async () => {
+    const ext = await loadExtension();
+    const pi1 = makeMockPi();
+    const pi2 = makeMockPi();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      ext(pi1);
+      ext(pi2);
+      const msg = String(errSpy.mock.calls[0][0]);
+      expect(msg).toContain("DUAL INSTANCE BLOCKED");
+      expect(msg).toContain("If the paths are identical");
+      expect(msg).toContain("should self-resolve");
+    } finally {
+      errSpy.mockRestore();
+    }
   });
 });
 

--- a/plugins/pi/extensions/neuralwatt-mcr.ts
+++ b/plugins/pi/extensions/neuralwatt-mcr.ts
@@ -63,7 +63,26 @@ import { randomUUID } from "node:crypto";
 //           short neutral placeholder and never resolves the hash; this is
 //           purely cosmetic — the gateway repairs the conversation either
 //           way.
-const EXTENSION_VERSION = "2.5.0";
+//   2.5.1 — dual-instance guard: stop the permanent-lockout false positive
+//           (Nico, 2026-06-12). Pi re-runs every extension factory IN-PROCESS
+//           on /new, /resume, fork and /reload (AgentSessionRuntime
+//           teardownCurrent → createRuntime → resourceLoader.reload() →
+//           loadExtensions; jiti moduleCache:false re-evaluates the module
+//           but globalThis persists). The 2.4.0 sentinel was never cleared,
+//           so the re-activation was blocked as a "dual instance" while pi
+//           had already discarded the prior activation's handlers — leaving
+//           ZERO active copies (MCR + the whole neuralwatt provider silently
+//           gone) for the rest of the process. Fix: (a) the winner releases
+//           the sentinel in its session_shutdown handler — pi emits
+//           session_shutdown before every teardown path that precedes a
+//           re-load; (b) belt-and-braces heartbeat: the winner stamps the
+//           sentinel on every event it handles, and a claimant may STEAL a
+//           sentinel whose heartbeat is older than DUAL_INSTANCE_STALE_MS
+//           (logged as ``dual_instance_steal_stale``). True dual-load at
+//           startup still blocks — both copies activate within milliseconds,
+//           so the loser always sees a fresh heartbeat. tools#44 protection
+//           preserved; the lockout is gone.
+const EXTENSION_VERSION = "2.5.1";
 
 // ── Provider definition (folded in from the former configs/models.json) ─────
 // Declaring the full provider config inline lets this extension be a
@@ -133,12 +152,50 @@ function nwlog(event: string, data: Record<string, unknown> = {}): void {
 // loaded from different paths each get their own module scope (exactly what
 // the dual-load evidence shows), so a module-scoped flag can never see the
 // other copy. globalThis is the only scope both copies share.
+//
+// 2.5.1 — the sentinel is no longer permanent. Pi re-runs every extension
+// factory IN-PROCESS on /new, /resume, fork and /reload (the old runner is
+// torn down and a fresh load pass re-evaluates this module; globalThis
+// survives the pass). A never-cleared sentinel therefore blocked every
+// re-activation after the first, with zero copies left registered. Two
+// complementary releases fix that without re-opening tools#44:
+//   (a) the winner deletes the sentinel in its session_shutdown handler —
+//       pi emits session_shutdown to the old runner before every teardown
+//       path that precedes a re-load;
+//   (b) the winner stamps sentinel.heartbeatTs on every event it handles,
+//       and a claimant may steal a sentinel whose heartbeat is older than
+//       DUAL_INSTANCE_STALE_MS (covers hosts that reload resources without
+//       emitting session_shutdown, e.g. the SDK's resourceLoader.reload()).
+// A genuine dual-load (auto-load + -e copy in ONE load pass) still blocks:
+// both copies activate within milliseconds, so the loser always sees a
+// fresh heartbeat.
 const DUAL_INSTANCE_SENTINEL_KEY = "__NEURALWATT_MCR_ACTIVE__";
+
+// A prior activation whose heartbeat is older than this is considered dead
+// (pi discarded its runner without the session_shutdown release firing) and
+// may be replaced. Copies racing within one load pass claim within
+// milliseconds, so 30s cannot misfire on a live dual-load.
+const DUAL_INSTANCE_STALE_MS = 30_000;
 
 interface DualInstanceSentinel {
   version: string;
   module: string;
   ts: string;
+  /** Unique id of the activation holding the claim (2.5.1+). */
+  activationId?: string;
+  /** Last time the holder handled an event, ms epoch (2.5.1+). */
+  heartbeatTs?: number;
+}
+
+// Unique per-ACTIVATION ownership token (never memoized — see the note at
+// the claim site in the default export). Defensive fallback mirrors the
+// guard's fail-open posture: id generation must never break activation.
+function newActivationId(): string {
+  try {
+    return randomUUID();
+  } catch {
+    return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  }
 }
 
 // Best-effort hint of which file this module copy was loaded from, so the
@@ -152,25 +209,55 @@ function moduleHint(): string {
 }
 
 // Claim the process-global activation sentinel. Returns the already-active
-// instance's sentinel when another copy won (caller must NOT register), or
-// null when this copy holds the claim and may register normally.
+// instance's sentinel when another LIVE copy won (caller must NOT register),
+// or null when this copy holds the claim — fresh, stolen-stale, or
+// fail-open — and may register normally.
+//
+// Staleness: a sentinel whose heartbeat is older than DUAL_INSTANCE_STALE_MS
+// belongs to an activation pi already discarded (see the release notes on
+// DUAL_INSTANCE_SENTINEL_KEY) — steal it and log `dual_instance_steal_stale`.
+// A sentinel WITHOUT a heartbeat (written by a ≤2.5.0 copy) is never stolen:
+// that copy never refreshes, so "stale" cannot be distinguished from "live",
+// and a mixed-version install is exactly the tools#44 dual-load we must keep
+// blocking.
 //
 // Resilience: a frozen/sealed globalThis (or any other exotic environment
 // where the read/write throws) must NEVER break activation — fail OPEN to
 // registering and log the anomaly. A doubly-registered extension is the
 // known-bad state we already survived; a never-registered one is strictly
 // worse (no MCR at all).
-function claimDualInstanceSentinel(): DualInstanceSentinel | null {
+function claimDualInstanceSentinel(
+  activationId: string,
+): DualInstanceSentinel | null {
   try {
     const g = globalThis as unknown as Record<string, unknown>;
     const existing = g[DUAL_INSTANCE_SENTINEL_KEY];
     if (existing && typeof existing === "object") {
-      return existing as DualInstanceSentinel;
+      const prior = existing as DualInstanceSentinel;
+      const heartbeatAge =
+        typeof prior.heartbeatTs === "number"
+          ? Date.now() - prior.heartbeatTs
+          : null;
+      if (heartbeatAge === null || heartbeatAge <= DUAL_INSTANCE_STALE_MS) {
+        return prior;
+      }
+      nwlog("dual_instance_steal_stale", {
+        prior: {
+          version: prior.version,
+          module: prior.module,
+          ts: prior.ts,
+          heartbeat_age_ms: heartbeatAge,
+        },
+        claimant: { version: EXTENSION_VERSION, module: moduleHint() },
+      });
+      // fall through to claim
     }
     const sentinel: DualInstanceSentinel = {
       version: EXTENSION_VERSION,
       module: moduleHint(),
       ts: new Date().toISOString(),
+      activationId,
+      heartbeatTs: Date.now(),
     };
     g[DUAL_INSTANCE_SENTINEL_KEY] = sentinel;
     return null;
@@ -179,6 +266,41 @@ function claimDualInstanceSentinel(): DualInstanceSentinel | null {
       error: err instanceof Error ? err.message : String(err),
     });
     return null;
+  }
+}
+
+// Refresh the heartbeat — called from every event handler the winner
+// registers. Ownership-checked so a late event on an already-torn-down
+// runner can never freshen (or resurrect) a claim it no longer holds.
+function touchDualInstanceSentinel(activationId: string): void {
+  try {
+    const g = globalThis as unknown as Record<string, unknown>;
+    const sentinel = g[DUAL_INSTANCE_SENTINEL_KEY] as
+      | DualInstanceSentinel
+      | undefined;
+    if (sentinel && typeof sentinel === "object" && sentinel.activationId === activationId) {
+      sentinel.heartbeatTs = Date.now();
+    }
+  } catch {
+    // never break a handler on guard bookkeeping
+  }
+}
+
+// Release the claim on session_shutdown so the re-activation pi performs on
+// /new, /resume, fork and /reload registers cleanly. Ownership-checked: a
+// blocked copy (which never claimed) and a superseded activation must not
+// delete the current holder's sentinel.
+function releaseDualInstanceSentinel(activationId: string): void {
+  try {
+    const g = globalThis as unknown as Record<string, unknown>;
+    const sentinel = g[DUAL_INSTANCE_SENTINEL_KEY] as
+      | DualInstanceSentinel
+      | undefined;
+    if (sentinel && typeof sentinel === "object" && sentinel.activationId === activationId) {
+      delete g[DUAL_INSTANCE_SENTINEL_KEY];
+    }
+  } catch {
+    // never break shutdown on guard bookkeeping
   }
 }
 
@@ -609,15 +731,23 @@ function computeDropRange(
 }
 
 export default function (pi: ExtensionAPI) {
-  // ── Dual-instance guard (tools#44): first activation wins ──
+  // ── Dual-instance guard (tools#44): first LIVE activation wins ──
   // Claim the process-global sentinel BEFORE registering anything (provider,
-  // handlers, env seeds). If another copy of this extension already activated
+  // handlers, env seeds). If another copy of this extension is already live
   // in this process — pi auto-loads ~/.pi/agent/extensions/neuralwatt-mcr.ts
   // in addition to any `-e <path>` copy — register NOTHING: a second
   // drop-protocol state machine racing the first on the same session is the
   // proven mechanism behind the 2026-06-09 runaway. Log loudly to both the
   // extension log (greppable forensics) and stderr (visible interactively).
-  const activeInstance = claimDualInstanceSentinel();
+  // A STALE claim (prior activation torn down without releasing) is stolen
+  // instead — see claimDualInstanceSentinel.
+  //
+  // NOT getUuidFallback(): that id is memoized per-process (by design, for
+  // the conversation-id boot seed), but the activation id must be unique PER
+  // ACTIVATION — it is the ownership token that lets touch/release tell the
+  // current claim holder from a superseded one in the same process.
+  const activationId = newActivationId();
+  const activeInstance = claimDualInstanceSentinel(activationId);
   if (activeInstance) {
     const loser = { version: EXTENSION_VERSION, module: moduleHint() };
     nwlog("dual_instance_blocked", { winner: activeInstance, loser });
@@ -625,8 +755,11 @@ export default function (pi: ExtensionAPI) {
       `[neuralwatt-mcr] DUAL INSTANCE BLOCKED: extension v${loser.version} ` +
         `(${loser.module}) did NOT register — v${activeInstance.version} ` +
         `(${activeInstance.module}) is already active in this process. ` +
-        `Pi auto-loads ~/.pi/agent/extensions/neuralwatt-mcr.ts in addition ` +
-        `to any -e <path> copy; remove the duplicate so only one copy loads ` +
+        `If the two paths differ, two copies are loading (pi auto-loads ` +
+        `~/.pi/agent/extensions/neuralwatt-mcr.ts in addition to any ` +
+        `-e <path> copy) — remove one. If the paths are identical or you ` +
+        `have no -e copy, this is likely a same-process re-activation and ` +
+        `should self-resolve from v2.5.1 — please report if it persists ` +
         `(see neuralwatt-tools#44).`,
     );
     return;
@@ -851,6 +984,7 @@ export default function (pi: ExtensionAPI) {
   }
 
   pi.on("session_start", async (_event, ctx) => {
+    touchDualInstanceSentinel(activationId);
     // #4111: clear the active branch suffix at session boot so a fresh pi
     // invocation always starts with the bare session id on the wire. Branch
     // navigation later in the session (``session_tree``) re-pins this.
@@ -915,6 +1049,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("after_provider_response", async (event, ctx) => {
+    touchDualInstanceSentinel(activationId);
     const modelId = ctx.model?.id || "";
     if (!isMCRModel(modelId)) return;
 
@@ -989,12 +1124,14 @@ export default function (pi: ExtensionAPI) {
   // streaming update (text/thinking/toolcall deltas); we don't need to narrow
   // further since any of these prove the wait is over.
   pi.on("message_update", async (event, ctx) => {
+    touchDualInstanceSentinel(activationId);
     if (event.message.role !== "assistant") return;
     if (!isMCRModel(ctx.model?.id || "")) return;
     markStreamProducing(ctx);
   });
 
   pi.on("message_end", async (event, ctx) => {
+    touchDualInstanceSentinel(activationId);
     if (event.message.role !== "assistant") return;
     if (!isMCRModel(ctx.model?.id || "")) return;
 
@@ -1039,6 +1176,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("context", async (event, ctx) => {
+    touchDualInstanceSentinel(activationId);
     const modelId = ctx.model?.id || "";
     const numMsgs = event.messages.length;
 
@@ -1178,6 +1316,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("before_provider_request", async (event, ctx) => {
+    touchDualInstanceSentinel(activationId);
     if (!isMCRModel(ctx.model?.id || "")) return;
 
     const payload = event.payload as Record<string, unknown>;
@@ -1272,6 +1411,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("session_before_compact", async (_event, ctx) => {
+    touchDualInstanceSentinel(activationId);
     if (!isMCRModel(ctx.model?.id || "")) return;
     if (state.sessionFp) {
       nwlog("compaction_cancelled", { session_fp: state.sessionFp });
@@ -1280,6 +1420,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("session_tree", async (event, ctx) => {
+    touchDualInstanceSentinel(activationId);
     // Branch navigation invalidates MCR session state — sessionFp and
     // safeDropBefore are tied to a specific message sequence that no
     // longer matches the new branch. Clear everything and let the
@@ -1342,6 +1483,12 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("session_shutdown", async (_event, ctx) => {
+    // Release the dual-instance claim FIRST (before anything below can
+    // throw): pi emits session_shutdown to this (old) runner before every
+    // teardown that precedes an in-process re-load (/new, /resume, fork,
+    // /reload — AgentSessionRuntime.teardownCurrent / AgentSession.reload),
+    // so the re-activation that follows must find the slot free.
+    releaseDualInstanceSentinel(activationId);
     nwlog("session_shutdown", {
       final_session_fp: state.sessionFp,
       total_energy_joules: state.totalEnergyJoules,

--- a/plugins/pi/package-lock.json
+++ b/plugins/pi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neuralwatt/pi-mcr-extension",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neuralwatt/pi-mcr-extension",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "MIT",
       "devDependencies": {
         "typebox": "^1.1.38",

--- a/plugins/pi/package.json
+++ b/plugins/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neuralwatt/pi-mcr-extension",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Neuralwatt MCR extension for Pi — 1M virtual context via server-side compaction",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Fixes the dual-instance guard false positive Nico reported (2026-06-12):

> "I get this a lot, I have tried removing it and adding it again and still get this when multiple pi instances opened: [neuralwatt-mcr] DUAL INSTANCE BLOCKED: extension vX.X.X (<module_path>) did NOT register — vX.X.X (<module_path>) is already active in this process. …"

He had no duplicate copy to remove. The guard (shipped in 2.4.0 for #44) was firing on pi's normal in-process re-activation — and each fire left **zero** registered copies: MCR and the entire neuralwatt provider silently off for the rest of the process.

## Lifecycle findings (pi-coding-agent 0.73.x dist source)

**1. Each interactive pi window is its own OS process** — `globalThis` is never shared across terminals, so "multiple pi instances opened" cannot literally collide on the sentinel. The correlation is indirect: with several windows open you `/resume`, `/new` and session-switch more, and *those* are the trigger.

**2. Pi re-runs every extension factory IN-PROCESS on `/new`, `/resume`, fork and `/reload`:**
- `/new` / `/resume` / fork: `AgentSessionRuntime.newSession/switchSession/fork` → `teardownCurrent()` → `createRuntime` (`core/agent-session-runtime.js:125-238`) → `createAgentSessionServices` (`main.js:464-466`) → **new** `DefaultResourceLoader` + `await resourceLoader.reload()` (`core/agent-session-services.js:60-66`) → `loadExtensions` (`core/resource-loader.js:274`) → `await factory(api)` (`core/extensions/loader.js:305`).
- `/reload`: `interactive-mode.js:4114` → `AgentSession.reload()` (`core/agent-session.js:1930-1948`) → `resourceLoader.reload()` → same path.
- The extension loader's jiti is created with `moduleCache: false` (`core/extensions/loader.js:265-271`), so the module re-evaluates each pass — module scope is fresh, but `globalThis` persists. The 2.4.0 sentinel was never cleared → every re-activation after the first was blocked, while pi had **already discarded** the previous activation's `ExtensionRunner` (`agent-session.js:1915` builds a fresh one). Net effect: 0 live copies, silently.

**3. Pi DOES expose a deactivation surface:** `session_shutdown` (`core/extensions/types.d.ts:420-427`, reasons `quit | reload | new | resume | fork` — "Fired before an extension runtime is torn down due to quit, reload, or session replacement"). It is emitted on every teardown path that precedes a re-load: `teardownCurrent` (`agent-session-runtime.js:102-110`), `dispose` (`:279-285`), and `AgentSession.reload` (`agent-session.js:1932`). There is no other dispose/cleanup hook on `ExtensionAPI`.

**4. Same-file double-load:** `discoverAndLoadExtensions` dedupes by `path.resolve` (`loader.js:447-456`), so the extensions dir + an identical configured path collapse to one load — but symlinked duplicates (no realpath) and genuinely separate copies (auto-load + `-e <other path>`) still load twice. That remains the true #44 case and must keep blocking.

**5. No in-process subagents** — at most one live runner generation per process, so "stale claim" is well-defined.

## Fix (both mechanisms, because pi supports both)

- **(a) Release on `session_shutdown`** (cleanest, covers the interactive paths above): the winner deletes the sentinel at the top of its existing `session_shutdown` handler, so the re-activation that follows finds the slot free.
- **(b) Heartbeat staleness as backup**: the winner stamps `sentinel.heartbeatTs` on every event it handles; a claimant may **steal** a claim whose heartbeat is older than 30s, logged distinctly as `dual_instance_steal_stale`. This covers hosts that reload resources *without* emitting `session_shutdown` (e.g. the SDK's `resourceLoader.reload()`, `core/sdk.js:76`) and any crashed teardown.
- **Ownership token**: each activation mints a unique id (deliberately *not* the memoized `getUuidFallback()`); touch/release are ownership-checked so a late event or shutdown from a superseded activation can never refresh or delete the current holder's claim.
- **Legacy sentinels (≤2.5.0, no heartbeat) are never stolen** — that copy never refreshes, so stale is indistinguishable from live, and a mixed-version install is exactly the #44 dual-load.
- **Message**: now distinguishes the two cases — paths differ → remove a copy; paths identical / no `-e` copy → same-process re-activation, self-resolves from 2.5.1, report if it persists.

## How #44 protection is preserved

A genuine dual-load happens within ONE `loadExtensions` pass: both copies activate within milliseconds, so the second copy always sees a fresh heartbeat and registers nothing — exactly the 2.4.0 behavior. The runaway stays dead; only the cross-generation lockout is gone.

## Test plan

- [x] `npm test` in `plugins/pi` — 30/30 pass (vitest)
- [x] New: `session_shutdown` releases the claim → next activation registers
- [x] New: stale-heartbeat steal succeeds + logs `dual_instance_steal_stale` (not `dual_instance_blocked`)
- [x] New: fresh-heartbeat second copy still blocks (true dual-load)
- [x] New: winner's heartbeat refreshes on handled events (`context`, `before_provider_request`)
- [x] New: superseded activation's late `session_shutdown` cannot release the new holder's claim
- [x] New: legacy (≤2.5.0) heartbeat-less sentinel is never stolen
- [x] Existing #44 guard + self-heal + protocol tests unchanged and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)