### PR TITLE
fix(pi-ext): honor safe_drop_before in single-prompt sessions when conv-id is set (2.5.2)

### DIFF
--- a/plugins/pi/README.md
+++ b/plugins/pi/README.md
@@ -13,7 +13,7 @@ When you select a Neuralwatt MCR model (e.g., `neuralwatt/kimi-k2.6-long`, `neur
 - **Context drop** — Reads `X-MCR-Safe-Drop-Before` from response headers and trims old messages the server has already stored, keeping the client bounded while the server maintains a 1M+ virtual context window.
 - **Session fingerprint** — Sends `X-MCR-Session-FP` on subsequent requests so the server can resume the same compacted session directly across turns and auto-compact boundaries.
 - **Compaction suppression** — Cancels Pi's built-in compaction when MCR is active (the server handles it).
-- **Anchor protection** — Preserves the first 3 user messages (MCR's fingerprint anchors) so sessions stay stable.
+- **Anchor protection** — In the content-anchor fallback (no conversation id on the wire), preserves the first 3 user messages, which the server fingerprints for session identity. When a conversation id IS sent (the normal case — this extension always wires `X-NW-Conversation-ID`), the server keys identity on the conversation id instead, so the anchor floor is unnecessary and the drop honors `safe_drop_before` directly. This lets single-prompt agentic sessions (1 user message + many tool turns) drop normally instead of resending the whole history every turn (2.5.2).
 - **Energy + MCR status bar** — Adds `nw-mcr` (session fingerprint + current drop threshold) and `nw-energy` (cumulative energy + APC cache hit rate + compaction ratio) to Pi's footer.
 - **Version reporting** — Sends the extension version on every request as the `X-NW-MCR-Ext-Version` header so the gateway can log which client revision served a request (handy when triaging a report — server logs previously had no way to tell a user's extension version).
 

--- a/plugins/pi/extensions/neuralwatt-mcr.test.ts
+++ b/plugins/pi/extensions/neuralwatt-mcr.test.ts
@@ -404,7 +404,7 @@ describe("#44 dual-instance guard", () => {
     const sentinel = (globalThis as Record<string, unknown>)
       .__NEURALWATT_MCR_ACTIVE__ as Record<string, unknown>;
     expect(sentinel).toBeTruthy();
-    expect(sentinel.version).toBe("2.5.1");
+    expect(sentinel.version).toBe("2.5.2");
     expect(typeof sentinel.module).toBe("string");
     expect(typeof sentinel.ts).toBe("string");
     // 2.5.1: the claim carries an activation id (ownership for touch/release)
@@ -414,7 +414,7 @@ describe("#44 dual-instance guard", () => {
 
     // The wire-visible version (X-NW-MCR-Ext-Version env seed) matches the
     // bump, so prod can verify the rollout.
-    expect(process.env.X_NW_MCR_EXT_VERSION).toBe("2.5.1");
+    expect(process.env.X_NW_MCR_EXT_VERSION).toBe("2.5.2");
   });
 
   it("second activation in the same process registers NOTHING and logs dual_instance_blocked", async () => {
@@ -439,8 +439,8 @@ describe("#44 dual-instance guard", () => {
         .find((l) => l.includes("dual_instance_blocked"));
       expect(blockedLine).toBeTruthy();
       const blocked = JSON.parse(blockedLine!);
-      expect(blocked.winner.version).toBe("2.5.1");
-      expect(blocked.loser.version).toBe("2.5.1");
+      expect(blocked.winner.version).toBe("2.5.2");
+      expect(blocked.loser.version).toBe("2.5.2");
 
       // …and on stderr (visible interactively).
       expect(errSpy).toHaveBeenCalled();
@@ -538,7 +538,7 @@ describe("2.5.1 dual-instance guard: stale-sentinel release (Nico false positive
     expect(stealLine).toBeTruthy();
     const steal = JSON.parse(stealLine!);
     expect(steal.prior.heartbeat_age_ms).toBeGreaterThan(30_000);
-    expect(steal.claimant.version).toBe("2.5.1");
+    expect(steal.claimant.version).toBe("2.5.2");
     expect(readLog()).not.toContain("dual_instance_blocked");
   });
 
@@ -663,12 +663,16 @@ describe("#44 post-drop stale-window self-heal", () => {
     };
   }
 
-  // History shape: 3 user anchors early (anchor floor = index 4, so
-  // dropStart = 5), then identical tool turns appended at the tail. Identical
-  // tail messages let a test freeze the window SIGNATURE (length + last-msg
-  // role/content-length) while the history grows, by moving safe_drop_before
-  // in lock-step — the simulated equivalent of whatever swallowed the new
-  // turns in prod.
+  // History shape: 3 user anchors early, then identical tool turns appended at
+  // the tail. These tests call session_start, so a well-formed conv-id is on
+  // the wire and (since 2.5.2) the drop honors safe_drop_before directly with
+  // dropStart = 0 — the anchor floor no longer applies. So `mkMsgs(n)` with
+  // safe_drop_before = s yields a window of n - s messages (indices [s, n)).
+  // Identical tail messages let a test freeze the window SIGNATURE (length +
+  // last-msg role/content-length) while the history grows, by moving
+  // safe_drop_before in lock-step — the simulated equivalent of whatever
+  // swallowed the new turns in prod. The stale-window invariant under test is
+  // orthogonal to where dropStart begins.
   function mkMsgs(n: number): Array<Record<string, unknown>> {
     const msgs: Array<Record<string, unknown>> = [
       { type: "user", content: "u1" },
@@ -712,17 +716,17 @@ describe("#44 post-drop stale-window self-heal", () => {
       const context = pi.handlers.get("context")!;
 
       // Turn 1: server authorizes drop<8; window built normally (baseline).
-      // drop range [5, 8) -> 7 of 10 messages go out.
+      // conv-id mode -> drop range [0, 8) -> 2 of 10 messages go out.
       await serverConfirm(pi, ctx, 8);
       const r1 = await context({ messages: mkMsgs(10) }, ctx);
-      expect(r1.messages).toHaveLength(7);
+      expect(r1.messages).toHaveLength(2);
 
       // Turn 2: local history grew (11 msgs) but the outgoing window is
       // shape-identical (same length, same tail) — trigger 1 of 2. Still
       // drops normally.
       await serverConfirm(pi, ctx, 9);
       const r2 = await context({ messages: mkMsgs(11) }, ctx);
-      expect(r2.messages).toHaveLength(7);
+      expect(r2.messages).toHaveLength(2);
       expect(readLog()).not.toContain("stale_window_self_heal");
 
       // Turn 3: frozen again while local grew — trigger 2 = N. SELF-HEAL:
@@ -738,7 +742,7 @@ describe("#44 post-drop stale-window self-heal", () => {
       expect(healLine).toBeTruthy();
       const heal = JSON.parse(healLine!);
       expect(heal.repeats).toBe(2);
-      expect(heal.window_len).toBe(7);
+      expect(heal.window_len).toBe(2);
       expect(heal.local_len).toBe(12);
       expect(errSpy).toHaveBeenCalled();
       expect(String(errSpy.mock.calls[0][0])).toContain(
@@ -769,10 +773,10 @@ describe("#44 post-drop stale-window self-heal", () => {
     // The same 10-message history sent 4 times (e.g. network retries): the
     // window signature is identical every time but the local history has NOT
     // grown, so the two-sided trigger stays false and the drop keeps
-    // applying.
+    // applying. conv-id mode -> drop [0, 8) -> 2 of 10 go out each time.
     for (let i = 0; i < 4; i++) {
       const r = await context({ messages: mkMsgs(10) }, ctx);
-      expect(r.messages).toHaveLength(7);
+      expect(r.messages).toHaveLength(2);
     }
     expect(readLog()).not.toContain("stale_window_self_heal");
   });
@@ -787,10 +791,11 @@ describe("#44 post-drop stale-window self-heal", () => {
 
     // safe_drop_before stays fixed while the history grows — the healthy
     // shape: the window's tail carries each new local turn, so the signature
-    // advances every request and the streak never starts.
+    // advances every request and the streak never starts. conv-id mode drops
+    // [0, 8) -> the window is n - 8 messages and grows with n.
     for (let n = 10; n <= 14; n++) {
       const r = await context({ messages: mkMsgs(n) }, ctx);
-      expect(r.messages).toHaveLength(n - 3); // fixed 3-message drop range
+      expect(r.messages).toHaveLength(n - 8); // fixed drop<8, window grows with n
     }
     expect(readLog()).not.toContain("stale_window_self_heal");
   });
@@ -802,24 +807,227 @@ describe("#44 post-drop stale-window self-heal", () => {
     await pi.handlers.get("session_start")!({}, ctx);
     const context = pi.handlers.get("context")!;
 
-    // Baseline (10 msgs, drop<8 -> 7 out), then ONE frozen-while-growing
+    // Baseline (10 msgs, drop<8 -> 2 out), then ONE frozen-while-growing
     // request (trigger 1 of 2)…
     await serverConfirm(pi, ctx, 8);
     await context({ messages: mkMsgs(10) }, ctx);
     await serverConfirm(pi, ctx, 9);
     const r2 = await context({ messages: mkMsgs(11) }, ctx);
-    expect(r2.messages).toHaveLength(7);
+    expect(r2.messages).toHaveLength(2);
 
-    // …then the window ADVANCES (same drop<9, history grows -> 8 out): the
+    // …then the window ADVANCES (same drop<9, history grows -> 3 out): the
     // consecutive-trigger streak must reset…
     const r3 = await context({ messages: mkMsgs(12) }, ctx);
-    expect(r3.messages).toHaveLength(8);
+    expect(r3.messages).toHaveLength(3);
 
     // …so a later single frozen request is trigger 1 again, not 2 — no heal.
     await serverConfirm(pi, ctx, 10);
     const r4 = await context({ messages: mkMsgs(13) }, ctx);
-    expect(r4.messages).toHaveLength(8);
+    expect(r4.messages).toHaveLength(3);
     expect(readLog()).not.toContain("stale_window_self_heal");
+  });
+});
+
+describe("2.5.2 conv-id mode honors safe_drop_before below the anchor floor", () => {
+  // Tom 2026-06-11, prod session 2d876919, ext 2.5.1: a codebase-audit-from-
+  // ONE-prompt session (1 user message + hundreds of assistant/tool turns)
+  // never dropped. The content-anchor floor (`findAnchorFloor` for the 3rd
+  // user message) returned -1 with <3 user messages, so `computeDropRange`
+  // returned an empty range and the extension emitted
+  // `context_no_drop reason=empty_range` every turn while the server's
+  // safe_drop_before climbed — the client re-sent the full ever-growing
+  // history forever (APC collapse, runaway cost). The floor is only needed
+  // for the server's content-anchor identity fallback (no conversation id);
+  // when a conv-id IS on the wire the server keys identity on it, so the
+  // floor must not block dropping.
+
+  function makeMCRCtx(sessionId: string) {
+    return {
+      model: { id: "neuralwatt/glm-5.1-long" },
+      sessionManager: { getSessionId: () => sessionId, getBranch: () => [] },
+      ui: { setStatus: () => {} },
+    };
+  }
+
+  // The server side of the drop handshake: confirm persisted history and
+  // authorize dropping everything before safeDropBefore.
+  async function serverConfirm(pi: MockPi, ctx: unknown, safeDropBefore: number) {
+    await pi.handlers.get("after_provider_response")!(
+      {
+        headers: {
+          "x-mcr-session-fp": "fp-test-2d87",
+          "x-mcr-safe-drop-before": String(safeDropBefore),
+          "x-mcr-stored-through": String(safeDropBefore),
+        },
+      },
+      ctx,
+    );
+  }
+
+  // Single-user-prompt agentic session: ONE user message, then n-1 mixed
+  // assistant/tool turns. This is the exact shape that hit anchorIdx === -1.
+  function mkSinglePrompt(n: number): Array<Record<string, unknown>> {
+    const msgs: Array<Record<string, unknown>> = [
+      { type: "user", content: "audit the whole codebase and fix the bugs" },
+    ];
+    let i = 0;
+    while (msgs.length < n) {
+      msgs.push(
+        i % 2 === 0
+          ? { type: "assistant", content: `step ${i}` }
+          : { type: "tool", content: `tool-result ${i}` },
+      );
+      i++;
+    }
+    return msgs;
+  }
+
+  // A session with >= 3 user messages (the content-anchor floor is satisfied).
+  function mkMultiPrompt(n: number): Array<Record<string, unknown>> {
+    const msgs: Array<Record<string, unknown>> = [
+      { type: "user", content: "u1" },
+      { type: "assistant", content: "a1" },
+      { type: "user", content: "u2" },
+      { type: "assistant", content: "a2" },
+      { type: "user", content: "u3" },
+      { type: "assistant", content: "a3" },
+    ];
+    let i = 0;
+    while (msgs.length < n) {
+      msgs.push({ type: "tool", content: `tool-result ${i++}` });
+    }
+    return msgs;
+  }
+
+  it("conv-id active + <3 user messages: drops [0, safeDrop), preserves the tail", async () => {
+    const pi = makeMockPi();
+    (await loadExtension())(pi);
+    const ctx = makeMCRCtx("sess-single-1");
+    // session_start upgrades X_NW_CONVERSATION_ID to the stable session id —
+    // a well-formed conv-id is now on the wire, so the anchor floor lifts.
+    await pi.handlers.get("session_start")!({}, ctx);
+    const context = pi.handlers.get("context")!;
+
+    await serverConfirm(pi, ctx, 5);
+    // 12 messages, 1 user message. Pre-fix this returned [0,0] (empty_range).
+    const r = await context({ messages: mkSinglePrompt(12) }, ctx);
+
+    // Drops the reconstructible prefix [0, 5): 5 messages gone, tail (>=5)
+    // intact -> 7 messages go out.
+    expect(r.messages).toHaveLength(7);
+    // The recent tail the server reserved (indices >= safeDropBefore) is never
+    // touched: the LAST local message is still present at the tail.
+    const sent = r.messages as Array<{ content?: unknown }>;
+    expect(sent[sent.length - 1].content).toBe("step 10");
+
+    // Distinct telemetry confirms a single-prompt drop happened.
+    const dropLine = readLog()
+      .split("\n")
+      .find((l) => l.includes('"context_drop"'));
+    expect(dropLine).toBeTruthy();
+    const drop = JSON.parse(dropLine!);
+    expect(drop.reason).toBe("convid_no_anchor");
+    expect(drop.drop_start).toBe(0);
+    expect(drop.drop_end).toBe(5);
+    expect(drop.conv_id_active).toBe(true);
+    expect(drop.user_msgs).toBe(1);
+    // The bug signature must NOT appear.
+    expect(readLog()).not.toContain("empty_range");
+  });
+
+  it("NO conv-id + <3 user messages: still drops nothing (content-anchor fallback intact)", async () => {
+    const pi = makeMockPi();
+    (await loadExtension())(pi);
+    const ctx = makeMCRCtx("sess-single-2");
+    const context = pi.handlers.get("context")!;
+
+    // Simulate the content-anchor fallback: NO conversation id on the wire.
+    // Do NOT call session_start (which would set the env var); clear the
+    // boot-seeded UUID so conversationIdActive() is false.
+    delete process.env.X_NW_CONVERSATION_ID;
+
+    await serverConfirm(pi, ctx, 5);
+    const r = await context({ messages: mkSinglePrompt(12) }, ctx);
+
+    // Fallback protection holds: fewer than 3 user messages -> drop nothing.
+    expect(r).toBeUndefined();
+    const noDropLine = readLog()
+      .split("\n")
+      .find((l) => l.includes('"context_no_drop"'));
+    expect(noDropLine).toBeTruthy();
+    const noDrop = JSON.parse(noDropLine!);
+    expect(noDrop.reason).toBe("empty_range");
+    expect(noDrop.conv_id_active).toBe(false);
+    expect(noDrop.user_msgs).toBe(1);
+  });
+
+  it(">=3 user messages, conv-id mode: drops from 0, tail preserved", async () => {
+    const pi = makeMockPi();
+    (await loadExtension())(pi);
+    const ctx = makeMCRCtx("sess-multi-convid");
+    await pi.handlers.get("session_start")!({}, ctx);
+    const context = pi.handlers.get("context")!;
+
+    await serverConfirm(pi, ctx, 5);
+    const r = await context({ messages: mkMultiPrompt(12) }, ctx);
+    // [0, 5) dropped -> 7 out; tail (indices >= 5) intact.
+    expect(r.messages).toHaveLength(7);
+    const drop = JSON.parse(
+      readLog().split("\n").find((l) => l.includes('"context_drop"'))!,
+    );
+    expect(drop.drop_start).toBe(0);
+    expect(drop.drop_end).toBe(5);
+    expect(drop.reason).toBe("convid"); // at/above the floor
+    expect(drop.user_msgs).toBe(3);
+  });
+
+  it(">=3 user messages, NO conv-id: unchanged legacy fallback (preserve first 3 user msgs)", async () => {
+    const pi = makeMockPi();
+    (await loadExtension())(pi);
+    const ctx = makeMCRCtx("sess-multi-fallback");
+    const context = pi.handlers.get("context")!;
+    // No conversation id on the wire -> content-anchor fallback.
+    delete process.env.X_NW_CONVERSATION_ID;
+
+    // 3rd user message is at index 4, so legacy dropStart = 5. Use a
+    // safeDropBefore beyond that so the range is non-empty.
+    await serverConfirm(pi, ctx, 8);
+    const r = await context({ messages: mkMultiPrompt(12) }, ctx);
+    // [5, 8) dropped -> 9 out; the 3 user anchors (indices 0,2,4) survive.
+    expect(r.messages).toHaveLength(9);
+    const sent = r.messages as Array<{ content?: unknown }>;
+    expect(sent.slice(0, 5).map((m) => m.content)).toEqual([
+      "u1",
+      "a1",
+      "u2",
+      "a2",
+      "u3",
+    ]);
+    const drop = JSON.parse(
+      readLog().split("\n").find((l) => l.includes('"context_drop"'))!,
+    );
+    expect(drop.drop_start).toBe(5);
+    expect(drop.reason).toBe("content_anchor");
+    expect(drop.conv_id_active).toBe(false);
+  });
+
+  it("conv-id mode never drops messages at/after safe_drop_before (reserved tail)", async () => {
+    const pi = makeMockPi();
+    (await loadExtension())(pi);
+    const ctx = makeMCRCtx("sess-tail-1");
+    await pi.handlers.get("session_start")!({}, ctx);
+    const context = pi.handlers.get("context")!;
+
+    // safeDropBefore = 9 on a 20-message single-prompt session: indices
+    // [0,9) drop, [9,20) (11 messages) are the reserved tail and must remain.
+    await serverConfirm(pi, ctx, 9);
+    const msgs = mkSinglePrompt(20);
+    const reservedTail = msgs.slice(9); // the messages that must survive
+    const r = await context({ messages: msgs }, ctx);
+
+    expect(r.messages).toHaveLength(11);
+    // Every reserved-tail message is present, in order, untouched.
+    expect((r.messages as Array<unknown>)).toEqual(reservedTail);
   });
 });
 

--- a/plugins/pi/extensions/neuralwatt-mcr.ts
+++ b/plugins/pi/extensions/neuralwatt-mcr.ts
@@ -82,7 +82,30 @@ import { randomUUID } from "node:crypto";
 //           startup still blocks — both copies activate within milliseconds,
 //           so the loser always sees a fresh heartbeat. tools#44 protection
 //           preserved; the lockout is gone.
-const EXTENSION_VERSION = "2.5.1";
+//   2.5.2 — honor `safe_drop_before` in single-prompt agentic sessions when a
+//           conversation id is in use (Tom 2026-06-11, prod session 2d876919).
+//           The content-anchor floor (preserve the first 3 user messages)
+//           refused to EVER drop when fewer than 3 user messages exist —
+//           `findAnchorFloor` returned -1 and `computeDropRange` returned an
+//           empty range. A codebase-audit-from-ONE-prompt session (1 user msg
+//           + hundreds of assistant/tool turns) hit that path every turn,
+//           emitting `context_no_drop reason=empty_range` forever while the
+//           server's `safe_drop_before` climbed (63→189) and num_msgs grew
+//           (114→172+). The client re-sent the full ever-growing history every
+//           turn, driving server compaction churn, APC collapse (~5%), and a
+//           runaway ($10.57 / 9.5M tokens / 16 min). Root cause: the 3-user-
+//           message floor exists ONLY to protect the server's content-anchor
+//           identity fallback (fingerprinting the first 3 user messages when
+//           NO conversation id is sent). This extension always sends a
+//           well-formed X-NW-Conversation-ID, so the server keys identity on
+//           the conv-id and the floor is unnecessary. Fix: in conv-id mode the
+//           floor no longer blocks dropping — dropStart becomes 0 and the
+//           reconstructible prefix [0, safe_drop_before) drops (the reserved
+//           recent tail at/after safe_drop_before is never touched). The
+//           content-anchor fallback path (no conv-id) keeps the 3-user-message
+//           protection exactly as before. New `context_drop reason=convid_no_anchor`
+//           telemetry confirms single-prompt sessions now drop.
+const EXTENSION_VERSION = "2.5.2";
 
 // ── Provider definition (folded in from the former configs/models.json) ─────
 // Declaring the full provider config inline lets this extension be a
@@ -120,6 +143,14 @@ const NEURALWATT_MODELS = [
 ] as const;
 
 const MCR_ANCHOR_USER_MESSAGES = 3;
+
+// Name of the env var that carries the conversation id onto the wire as the
+// `X-NW-Conversation-ID` header (see the header-wiring note in the export
+// default). Module-scoped so both the provider registration AND the
+// content-anchor decision in `computeDropRange` read the same single name.
+// The SDK resolves a header value as an env-var NAME live per request, so
+// whatever this points at is exactly what the server receives.
+const CONV_ID_ENV = "X_NW_CONVERSATION_ID";
 
 const LOG_FILE = path.join(
   os.homedir(),
@@ -583,6 +614,25 @@ function isWellFormedConversationId(value: string): boolean {
   return true;
 }
 
+// True when a well-formed X-NW-Conversation-ID is currently being sent on the
+// wire (the live value of CONV_ID_ENV, which the SDK resolves into the header
+// per request). This extension ALWAYS wires the header — a per-process UUID
+// fallback is seeded at load and upgraded to pi's stable session id (and to a
+// per-branch id) — so in practice this is true for every MCR turn.
+//
+// It matters for the content-anchor floor (see `computeDropRange`): the
+// 3-user-message floor exists ONLY to protect the server's content-anchor
+// identity fallback, which fingerprints the first 3 user messages when NO
+// conversation id is sent. When a conv-id IS in use the server keys session
+// identity on the conv-id (mcr_v3_session.validate_client_conversation_id),
+// so those first 3 user messages carry no identity weight and the
+// authoritative `safe_drop_before` (clamped to stored_through, recent tail
+// reserved) is the only thing that gates dropping.
+function conversationIdActive(): boolean {
+  const id = process.env[CONV_ID_ENV];
+  return typeof id === "string" && isWellFormedConversationId(id);
+}
+
 // Per-process fallback id. Generated lazily so it stays stable across
 // auto-compact within one `pi` invocation, and differs across invocations.
 let uuidFallback: string | null = null;
@@ -717,14 +767,54 @@ const MCR_LOOKUP_PARAMS = Type.Object(
   { additionalProperties: true },
 );
 
+// Compute the full-array index range [dropStart, dropEnd) to drop, in the same
+// indexing space as the server's `safe_drop_before` (every message counted,
+// all roles). `dropEnd` is always `safeDropBefore`, so messages at/after it —
+// the recent tail the server explicitly reserved (safe_drop_before is clamped
+// to stored_through with keep-recent withheld) — are NEVER dropped.
+//
+// `convIdActive` decides where dropStart begins:
+//
+//   * convIdActive === false (content-anchor fallback): keep the existing
+//     3-user-message protection. The server has no conversation id and falls
+//     back to fingerprinting the first 3 user messages for session identity,
+//     so they must survive — dropStart = anchorIdx + 1, and if fewer than 3
+//     user messages exist (anchorIdx < 0) we drop NOTHING. This is the
+//     untouched legacy path.
+//
+//   * convIdActive === true (conv-id mode — the normal path for this
+//     extension): the server keys identity on X-NW-Conversation-ID, so the
+//     first 3 user messages carry no identity weight and the floor is
+//     unnecessary. dropStart starts at 0 so the full reconstructible prefix
+//     [0, safeDropBefore) can drop even in single-user-prompt agentic
+//     sessions (1 user msg + hundreds of assistant/tool turns), which used to
+//     hit anchorIdx === -1 and never drop — driving the unbounded-resend /
+//     APC-collapse runaway (Tom 2026-06-11, session 2d876919). When ≥3 user
+//     messages exist, dropStart is still 0 (a superset of the old
+//     anchorIdx+1), so behaviour only ever drops MORE of the already-safe
+//     prefix, never less — and never past safeDropBefore.
+//
+// Index-space correctness (the #bug-2026-05-16 over-drop fix) is preserved:
+// both bounds are full-array indices, and the dropEnd <= dropStart guard plus
+// the caller's clampedEnd keep us from ever touching the reserved tail.
 function computeDropRange(
   entries: Array<{ role?: string; type?: string }>,
   safeDropBefore: number,
+  convIdActive: boolean,
 ): [number, number] {
   if (safeDropBefore <= 0) return [0, 0];
-  const anchorIdx = findAnchorFloor(entries, MCR_ANCHOR_USER_MESSAGES);
-  if (anchorIdx < 0) return [0, 0];
-  const dropStart = anchorIdx + 1;
+  let dropStart: number;
+  if (convIdActive) {
+    // Conv-id mode: no content-anchor floor. Drop the whole reconstructible
+    // prefix [0, safeDropBefore).
+    dropStart = 0;
+  } else {
+    // Content-anchor fallback: preserve the first MCR_ANCHOR_USER_MESSAGES
+    // user messages exactly as before. Fewer than that → drop nothing.
+    const anchorIdx = findAnchorFloor(entries, MCR_ANCHOR_USER_MESSAGES);
+    if (anchorIdx < 0) return [0, 0];
+    dropStart = anchorIdx + 1;
+  }
   const dropEnd = safeDropBefore;
   if (dropEnd <= dropStart) return [0, 0];
   return [dropStart, dropEnd];
@@ -795,7 +885,8 @@ export default function (pi: ExtensionAPI) {
   // per-invocation session id (see resolveConversationId). Subsequent requests
   // in the same `pi` invocation reuse the upgraded value — invocation-stable
   // session_fp by construction, sent on the wire as X-NW-Conversation-ID.
-  const CONV_ID_ENV = "X_NW_CONVERSATION_ID";
+  // CONV_ID_ENV is module-scoped (defined near MCR_ANCHOR_USER_MESSAGES) so
+  // the content-anchor decision in `computeDropRange` reads the same name.
   if (!process.env[CONV_ID_ENV]) {
     process.env[CONV_ID_ENV] = getUuidFallback();
   }
@@ -1209,9 +1300,23 @@ export default function (pi: ExtensionAPI) {
       return;
     }
 
+    // Whether a well-formed X-NW-Conversation-ID is on the wire for this
+    // session. When true the server keys identity on the conv-id, so the
+    // content-anchor floor (first 3 user messages) is unnecessary and the
+    // drop may honor `safe_drop_before` even in single-user-prompt agentic
+    // sessions. When false the legacy 3-user-message protection stands.
+    // See `computeDropRange` / `conversationIdActive` for the full rationale
+    // (Tom 2026-06-11 never-drop runaway, session 2d876919).
+    const convIdActive = conversationIdActive();
+    const userMsgCount = (
+      event.messages as Array<{ role?: string; type?: string }>
+    ).filter((m) => entryRole(m) === "user").length;
+    const belowAnchorFloor = userMsgCount < MCR_ANCHOR_USER_MESSAGES;
+
     const [dropStart, dropEnd] = computeDropRange(
       event.messages as Array<{ type: string }>,
       state.safeDropBefore,
+      convIdActive,
     );
 
     if (dropEnd <= dropStart) {
@@ -1221,6 +1326,8 @@ export default function (pi: ExtensionAPI) {
         drop_end: dropEnd,
         safe_drop_before: state.safeDropBefore,
         num_msgs: numMsgs,
+        conv_id_active: convIdActive,
+        user_msgs: userMsgCount,
         session_fp: state.sessionFp,
       });
       return;
@@ -1303,12 +1410,25 @@ export default function (pi: ExtensionAPI) {
     state.prevLocalLen = localLen;
 
     nwlog("context_drop", {
+      // `convid_no_anchor` marks the case the never-drop bug used to block:
+      // conv-id mode dropping with fewer than 3 user messages (single-prompt
+      // agentic sessions). Distinct so prod log analysis can confirm these
+      // sessions now drop. `convid` = conv-id mode at/above the floor;
+      // `content_anchor` = the legacy fallback path.
+      reason:
+        convIdActive && belowAnchorFloor
+          ? "convid_no_anchor"
+          : convIdActive
+            ? "convid"
+            : "content_anchor",
       drop_start: dropStart,
       drop_end: clampedEnd,
       safe_drop_before: state.safeDropBefore,
       num_msgs_before: numMsgs,
       num_msgs_after: filtered.length,
       dropped: droppedCount,
+      conv_id_active: convIdActive,
+      user_msgs: userMsgCount,
       session_fp: state.sessionFp,
     });
 

--- a/plugins/pi/package-lock.json
+++ b/plugins/pi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neuralwatt/pi-mcr-extension",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neuralwatt/pi-mcr-extension",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "license": "MIT",
       "devDependencies": {
         "typebox": "^1.1.38",

--- a/plugins/pi/package.json
+++ b/plugins/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neuralwatt/pi-mcr-extension",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Neuralwatt MCR extension for Pi — 1M virtual context via server-side compaction",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Problem

Single-user-prompt agentic sessions in the pi MCR extension **never drop messages**, driving an unbounded-resend / APC-collapse runaway.

**Prod evidence** (Tom, 2026-06-11, session `2d876919`, ext 2.5.1):
- The extension emitted `context_no_drop reason=empty_range drop_start=0 drop_end=0` **every turn**, while the server's `safe_drop_before` climbed `63→189` and `num_msgs` grew `114→172+`.
- The client kept re-sending the full, ever-growing history each turn → server compaction churn, APC collapse (~5%), and a runaway: **$10.57 / 9.5M tokens / 16 min**.

**Root cause:** `findAnchorFloor(entries, MCR_ANCHOR_USER_MESSAGES=3)` walks for the 3rd `user` message and returns **-1 when fewer than 3 user messages exist**. `computeDropRange` then does `if (anchorIdx < 0) return [0,0]` → empty range → no drop. A codebase-audit-from-ONE-prompt session (1 user message + hundreds of assistant/tool turns) hits `anchorIdx === -1` on every turn and never drops.

## Why the anchor floor can be safely relaxed

The 3-user-message floor exists **ONLY** to protect the server's **content-anchor identity fallback** — the server fingerprints the first 3 user messages when no conversation id is sent. This extension **always** wires `X-NW-Conversation-ID` via `registerProvider` (the env-var-name header mechanism; there are `conversation_id_attached` events). When a conv-id is sent, the server keys session identity on the conv-id (`mcr_v3_session.validate_client_conversation_id`), **not** on the first 3 user messages — so preserving them is unnecessary. The server's `safe_drop_before` is already the authoritative guarantee of what it can reconstruct, and it already reserves the recent tail (clamps `safe_drop_before <= stored_through`, withholds keep-recent).

## The fix

`computeDropRange` now takes a `convIdActive` flag, computed at the caller from the live, well-formed `X-NW-Conversation-ID` (`conversationIdActive()`):

- **conv-id mode** (the normal path): the anchor floor no longer blocks dropping. `dropStart` becomes `0`, so the reconstructible prefix `[0, safe_drop_before)` drops even in single-prompt sessions. With ≥3 user messages this is a superset of the old `anchorIdx+1` start (drops more of the already-safe prefix, never less), and **never** touches messages at/after `safe_drop_before` (the reserved recent tail).
- **content-anchor fallback** (no conv-id): the existing 3-user-message protection is kept **exactly as-is** — `dropStart = anchorIdx + 1`, and `<3` user messages still drops nothing.

Index-space correctness is preserved (full-array indices matching the server's `safe_drop_before`; the `dropEnd <= dropStart` and `clampedEnd` guards from the #bug-2026-05-16 over-drop fix are untouched).

New telemetry: `context_drop reason=convid_no_anchor` (conv-id mode dropping with <3 user messages) so prod can confirm single-prompt sessions now drop; `convid` (conv-id mode at/above floor) and `content_anchor` (fallback) for completeness. Both `context_drop` and `context_no_drop` now log `conv_id_active` and `user_msgs`.

## Tests

Extended the vitest suite (`npm test` in `plugins/pi`, **35 passed**):
- conv-id active + <3 user messages → non-empty range honoring `safe_drop_before` (drops `[0, safeDrop)`), reserved tail intact, `reason=convid_no_anchor`.
- no conv-id + <3 user messages → still `[0,0]` (fallback protection intact, `reason=empty_range`).
- ≥3 user messages → conv-id mode drops from 0; fallback preserves the first 3 user messages (`reason=content_anchor`).
- conv-id mode never drops messages at/after `safe_drop_before` (reserved tail).

Pre-existing stale-window-self-heal tests updated for the new conv-id-mode drop start (the invariant under test is orthogonal to where `dropStart` begins); version assertions bumped to 2.5.2.

## Version

`EXTENSION_VERSION` → 2.5.2 (+ version-history entry referencing the never-drop bug and that conv-id mode no longer needs the anchor floor); `package.json` + `package-lock.json` bumped; README "Anchor protection" bullet updated.

## No local-only edits

Confirmed via `git diff`: the diff contains **no** `NEURALWATT_BASE_URL` env override and **no** canary model registrations (work was done in a fresh worktree based on committed `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)