### PR TITLE
fix(pi-ext): keep honoring safe_drop_before across session branches (2.5.3)

### DIFF
--- a/plugins/pi/extensions/neuralwatt-mcr.test.ts
+++ b/plugins/pi/extensions/neuralwatt-mcr.test.ts
@@ -113,12 +113,21 @@ function clearDualInstanceSentinel() {
   delete (globalThis as Record<string, unknown>).__NEURALWATT_MCR_ACTIVE__;
 }
 
+// 2.5.3: the cross-activation drop-state cache also lives on globalThis (it
+// must survive jiti module re-evaluation across a branch). The test module is
+// imported once, so this map persists across tests — clear it for isolation,
+// exactly like the dual-instance sentinel above.
+function clearDropStateCache() {
+  delete (globalThis as Record<string, unknown>).__NEURALWATT_MCR_DROP_STATE_V1__;
+}
+
 beforeEach(() => {
   // Reset the env-var seeds and the log between tests. Re-seed the conversation
   // id the same way the extension does at module load (it only seeds once).
   delete process.env.X_NW_CONVERSATION_ID;
   delete process.env.X_NW_MCR_EXT_VERSION;
   clearDualInstanceSentinel();
+  clearDropStateCache();
   try {
     fs.rmSync(logPath());
   } catch {
@@ -130,6 +139,7 @@ afterEach(() => {
   delete process.env.X_NW_CONVERSATION_ID;
   delete process.env.X_NW_MCR_EXT_VERSION;
   clearDualInstanceSentinel();
+  clearDropStateCache();
 });
 
 describe("X-NW-Conversation-ID header wiring", () => {
@@ -404,7 +414,7 @@ describe("#44 dual-instance guard", () => {
     const sentinel = (globalThis as Record<string, unknown>)
       .__NEURALWATT_MCR_ACTIVE__ as Record<string, unknown>;
     expect(sentinel).toBeTruthy();
-    expect(sentinel.version).toBe("2.5.2");
+    expect(sentinel.version).toBe("2.5.3");
     expect(typeof sentinel.module).toBe("string");
     expect(typeof sentinel.ts).toBe("string");
     // 2.5.1: the claim carries an activation id (ownership for touch/release)
@@ -414,7 +424,7 @@ describe("#44 dual-instance guard", () => {
 
     // The wire-visible version (X-NW-MCR-Ext-Version env seed) matches the
     // bump, so prod can verify the rollout.
-    expect(process.env.X_NW_MCR_EXT_VERSION).toBe("2.5.2");
+    expect(process.env.X_NW_MCR_EXT_VERSION).toBe("2.5.3");
   });
 
   it("second activation in the same process registers NOTHING and logs dual_instance_blocked", async () => {
@@ -439,8 +449,8 @@ describe("#44 dual-instance guard", () => {
         .find((l) => l.includes("dual_instance_blocked"));
       expect(blockedLine).toBeTruthy();
       const blocked = JSON.parse(blockedLine!);
-      expect(blocked.winner.version).toBe("2.5.2");
-      expect(blocked.loser.version).toBe("2.5.2");
+      expect(blocked.winner.version).toBe("2.5.3");
+      expect(blocked.loser.version).toBe("2.5.3");
 
       // …and on stderr (visible interactively).
       expect(errSpy).toHaveBeenCalled();
@@ -538,7 +548,7 @@ describe("2.5.1 dual-instance guard: stale-sentinel release (Nico false positive
     expect(stealLine).toBeTruthy();
     const steal = JSON.parse(stealLine!);
     expect(steal.prior.heartbeat_age_ms).toBeGreaterThan(30_000);
-    expect(steal.claimant.version).toBe("2.5.2");
+    expect(steal.claimant.version).toBe("2.5.3");
     expect(readLog()).not.toContain("dual_instance_blocked");
   });
 
@@ -1028,6 +1038,271 @@ describe("2.5.2 conv-id mode honors safe_drop_before below the anchor floor", ()
     expect(r.messages).toHaveLength(11);
     // Every reserved-tail message is present, in order, untouched.
     expect((r.messages as Array<unknown>)).toEqual(reservedTail);
+  });
+});
+
+describe("2.5.3 keeps honoring safe_drop_before across a session branch", () => {
+  // Regression: Tom 2026-06-14, ext 2.5.2. A pi BRANCH (session_shutdown then a
+  // module re-eval under jiti, then session_start with reason "fork"/"resume"/
+  // "reload") recreates the module-scoped `state` with sessionFp=null /
+  // safeDropBefore=0. The conv-id (= pi session id) PERSISTS across the re-eval,
+  // so the gateway keeps the same session_fp and keeps emitting
+  // safe_drop_before — but the freshly-wiped client hit `if (!state.sessionFp)
+  // return` (`context_skip no_session_fp`) and NEVER pruned, so the window ran
+  // away (1.36M client-window tokens, server safe_drop_before=615 ignored,
+  // repeating `session_shutdown final_session_fp=null`). A fresh non-branched
+  // session dropped fine; pi-vcc / dual-instance stacking was ruled out by repro.
+  // Fix: stash the drop high-water on globalThis (survives the jiti re-eval)
+  // keyed by the persistent conv-id and restore it when the conv-id matches.
+
+  function makeMCRCtx(sessionId: string) {
+    return {
+      model: { id: "neuralwatt/glm-5.1-long" },
+      sessionManager: { getSessionId: () => sessionId, getBranch: () => [] },
+      ui: { setStatus: () => {} },
+    };
+  }
+
+  async function serverConfirm(
+    pi: MockPi,
+    ctx: unknown,
+    safeDropBefore: number,
+    fp = "fp-branch-2d87",
+  ) {
+    await pi.handlers.get("after_provider_response")!(
+      {
+        headers: {
+          "x-mcr-session-fp": fp,
+          "x-mcr-safe-drop-before": String(safeDropBefore),
+          "x-mcr-stored-through": String(safeDropBefore),
+        },
+      },
+      ctx,
+    );
+  }
+
+  // Single-user-prompt agentic session (1 user msg + mixed assistant/tool
+  // turns) — the runaway shape. conv-id mode drops [0, safeDropBefore).
+  function mkSinglePrompt(n: number): Array<Record<string, unknown>> {
+    const msgs: Array<Record<string, unknown>> = [
+      { type: "user", content: "audit the whole codebase" },
+    ];
+    let i = 0;
+    while (msgs.length < n) {
+      msgs.push(
+        i % 2 === 0
+          ? { type: "assistant", content: `step ${i}` }
+          : { type: "tool", content: `tool-result ${i}` },
+      );
+      i++;
+    }
+    return msgs;
+  }
+
+  // Identical-tail history (1 user anchor + repeated identical tool turns). In
+  // conv-id mode the drop is [0, s), so the outgoing window is msgs[s..n): with
+  // s and n moving in lockstep the window length AND last-message identity stay
+  // fixed → the signature freezes while local history grows (the stale-window
+  // trigger). mkSinglePrompt's per-index content would change the tail and so
+  // never freeze.
+  function mkIdenticalTail(n: number): Array<Record<string, unknown>> {
+    const msgs: Array<Record<string, unknown>> = [
+      { type: "user", content: "u1" },
+    ];
+    while (msgs.length < n) msgs.push({ type: "tool", content: "tool-result" });
+    return msgs;
+  }
+
+  function dropCache(): Record<string, unknown> {
+    return (globalThis as Record<string, unknown>)
+      .__NEURALWATT_MCR_DROP_STATE_V1__ as Record<string, unknown>;
+  }
+
+  it("a branch (session_start fires, conv-id persists) still computes a non-empty drop on the next turn", async () => {
+    const ext = await loadExtension();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const pi1 = makeMockPi();
+      ext(pi1);
+      const ctx = makeMCRCtx("sess-branch-1");
+
+      // Boot + establish the server drop high-water; after_provider_response
+      // caches it under the conv-id (= "sess-branch-1").
+      await pi1.handlers.get("session_start")!({ reason: "startup" }, ctx);
+      await serverConfirm(pi1, ctx, 5);
+      expect(dropCache()["sess-branch-1"]).toMatchObject({
+        sessionFp: "fp-branch-2d87",
+        safeDropBefore: 5,
+      });
+
+      // Baseline: the drop applies normally (12 msgs, drop [0,5) -> 7 out).
+      const r0 = await pi1.handlers.get("context")!(
+        { messages: mkSinglePrompt(12) },
+        ctx,
+      );
+      expect(r0.messages).toHaveLength(7);
+
+      // ── BRANCH ──: pi tears the runner down and re-evaluates the module
+      // (fresh state, sessionFp=null), then re-activates and fires session_start
+      // with a branch reason. The conv-id is UNCHANGED (same pi session id).
+      await pi1.handlers.get("session_shutdown")!({ reason: "fork" }, ctx);
+      const pi2 = makeMockPi();
+      ext(pi2); // re-activation registers cleanly (sentinel was released)
+      expect(pi2.handlers.size).toBeGreaterThan(0);
+      await pi2.handlers.get("session_start")!({ reason: "fork" }, ctx);
+
+      // The fp self-healed from the cache at session_start.
+      const restoreLine = readLog()
+        .split("\n")
+        .find((l) => l.includes("drop_state_restored"));
+      expect(restoreLine).toBeTruthy();
+      const restored = JSON.parse(restoreLine!);
+      expect(restored.source).toBe("session_start");
+      expect(restored.reason).toBe("fork");
+      expect(restored.session_fp).toBe("fp-branch-2d87");
+      expect(restored.safe_drop_before).toBe(5);
+
+      // CRUCIAL: the very next context STILL drops — it did NOT get stuck in the
+      // no_session_fp skip that caused Tom's runaway. 13 msgs, drop [0,5) -> 8.
+      const r1 = await pi2.handlers.get("context")!(
+        { messages: mkSinglePrompt(13) },
+        ctx,
+      );
+      expect(r1).not.toBeUndefined();
+      expect(r1.messages).toHaveLength(8);
+      // The bug signature is absent across the whole branched flow.
+      expect(readLog()).not.toContain("no_session_fp");
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("a genuinely new conversation after a branch resets cleanly (no cross-conversation restore)", async () => {
+    const ext = await loadExtension();
+    const pi1 = makeMockPi();
+    ext(pi1);
+    const ctxA = makeMCRCtx("sess-A");
+    await pi1.handlers.get("session_start")!({ reason: "startup" }, ctxA);
+    await serverConfirm(pi1, ctxA, 5); // caches sess-A's high-water
+
+    // Teardown, then a brand-NEW session with a DIFFERENT id (e.g. /new).
+    await pi1.handlers.get("session_shutdown")!({ reason: "new" }, ctxA);
+    const pi2 = makeMockPi();
+    ext(pi2);
+    const ctxB = makeMCRCtx("sess-B-fresh");
+    await pi2.handlers.get("session_start")!({ reason: "new" }, ctxB);
+
+    // No cache entry for the new conv-id → NO restore at session_start.
+    expect(readLog()).not.toContain("drop_state_restored");
+
+    // First turn of the new conversation legitimately has no fp → skip (the
+    // correct clean-reset behaviour, NOT the runaway).
+    const r = await pi2.handlers.get("context")!(
+      { messages: mkSinglePrompt(12) },
+      ctxB,
+    );
+    expect(r).toBeUndefined();
+    expect(readLog()).toContain("no_session_fp");
+  });
+
+  it("the context backstop restores the fp when session_start did not (request-path self-heal)", async () => {
+    const ext = await loadExtension();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const pi = makeMockPi();
+      ext(pi);
+
+      // Seed a cached high-water for a conversation, as a prior activation's
+      // after_provider_response would have.
+      (globalThis as Record<string, unknown>).__NEURALWATT_MCR_DROP_STATE_V1__ = {
+        "sess-ctx-heal": {
+          sessionFp: "fp-cached-77",
+          safeDropBefore: 5,
+          storedThrough: 5,
+          ts: Date.now(),
+        },
+      };
+
+      // Boot an UNRELATED session so state.sessionFp is reset to null with no
+      // restore (no cache entry for "sess-unrelated").
+      const otherCtx = makeMCRCtx("sess-unrelated");
+      await pi.handlers.get("session_start")!({ reason: "startup" }, otherCtx);
+      expect(readLog()).not.toContain("drop_state_restored");
+
+      // Now the wire conv-id points at the cached conversation (a resume that
+      // re-derived this id) while state.sessionFp is still null. The context
+      // handler must restore from the cache and drop, NOT skip no_session_fp.
+      process.env.X_NW_CONVERSATION_ID = "sess-ctx-heal";
+      const r = await pi.handlers.get("context")!(
+        { messages: mkSinglePrompt(12) },
+        otherCtx,
+      );
+      expect(r).not.toBeUndefined();
+      expect(r.messages).toHaveLength(7); // [0,5) dropped
+      const restoreLine = readLog()
+        .split("\n")
+        .find((l) => l.includes("drop_state_restored"));
+      expect(restoreLine).toBeTruthy();
+      expect(JSON.parse(restoreLine!).source).toBe("context");
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("an expired (>TTL) cached high-water is not restored", async () => {
+    const ext = await loadExtension();
+    const pi = makeMockPi();
+    ext(pi);
+    // A day-and-change-old entry: the conversation is treated as ended.
+    (globalThis as Record<string, unknown>).__NEURALWATT_MCR_DROP_STATE_V1__ = {
+      "sess-stale": {
+        sessionFp: "fp-old",
+        safeDropBefore: 5,
+        storedThrough: 5,
+        ts: Date.now() - (24 * 60 * 60 * 1000 + 60_000),
+      },
+    };
+    const ctx = makeMCRCtx("sess-stale");
+    await pi.handlers.get("session_start")!({ reason: "resume" }, ctx);
+    // Expired → no restore; the first response will re-establish the fp.
+    expect(readLog()).not.toContain("drop_state_restored");
+    const r = await pi.handlers.get("context")!(
+      { messages: mkSinglePrompt(12) },
+      ctx,
+    );
+    expect(r).toBeUndefined();
+    expect(readLog()).toContain("no_session_fp");
+  });
+
+  it("the stale-window self-heal clears the cached high-water so a later reload can't re-freeze", async () => {
+    const ext = await loadExtension();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const pi = makeMockPi();
+      ext(pi);
+      const ctx = makeMCRCtx("sess-heal-cache");
+      await pi.handlers.get("session_start")!({ reason: "startup" }, ctx);
+      const context = pi.handlers.get("context")!;
+
+      // Drive the stale-window invariant to a heal (window frozen while local
+      // history grows for N=2 consecutive requests — identical tail, s and n in
+      // lockstep so the window length and last message stay fixed).
+      await serverConfirm(pi, ctx, 8);
+      await context({ messages: mkIdenticalTail(10) }, ctx);
+      expect(dropCache()["sess-heal-cache"]).toBeTruthy();
+      await serverConfirm(pi, ctx, 9);
+      await context({ messages: mkIdenticalTail(11) }, ctx);
+      await serverConfirm(pi, ctx, 10);
+      const healed = await context({ messages: mkIdenticalTail(12) }, ctx);
+
+      expect(healed).toBeUndefined(); // full history sent
+      expect(readLog()).toContain("stale_window_self_heal");
+      // The cached high-water was dropped so a subsequent reload won't restore
+      // the pre-heal safe_drop_before and re-freeze the window.
+      expect(dropCache()["sess-heal-cache"]).toBeUndefined();
+    } finally {
+      errSpy.mockRestore();
+    }
   });
 });
 

--- a/plugins/pi/extensions/neuralwatt-mcr.ts
+++ b/plugins/pi/extensions/neuralwatt-mcr.ts
@@ -105,7 +105,39 @@ import { randomUUID } from "node:crypto";
 //           content-anchor fallback path (no conv-id) keeps the 3-user-message
 //           protection exactly as before. New `context_drop reason=convid_no_anchor`
 //           telemetry confirms single-prompt sessions now drop.
-const EXTENSION_VERSION = "2.5.2";
+//   2.5.3 — keep honoring `safe_drop_before` across a session BRANCH (Tom
+//           2026-06-14, ext 2.5.2). A pi branch/fork/resume/reload re-evaluates
+//           this extension module under jiti (`moduleCache:false` — see
+//           pi-coding-agent extensions/loader.js `loadExtensionModule`), so the
+//           module-scoped `state` is recreated fresh with `sessionFp: null` and
+//           `safeDropBefore: 0` on EVERY branch — independent of the
+//           session_start handler's own reset, and unavoidable in module scope.
+//           The wire `X-NW-Conversation-ID`, by contrast, PERSISTS across the
+//           re-eval (process.env survives it and resolveConversationId
+//           re-derives the same pi session id), so the gateway keeps the SAME
+//           session_fp and keeps emitting `safe_drop_before`. But the
+//           freshly-wiped client has no local sessionFp, so the `context`
+//           handler hit `if (!state.sessionFp) return` (`context_skip
+//           reason=no_session_fp`) and NEVER pruned — the window ran away
+//           (Tom: 1.36M client-window tokens, server `safe_drop_before=615`
+//           ignored, repeating `session_shutdown final_session_fp=null` +
+//           `context_skip no_session_fp`; a fresh non-branched session dropped
+//           fine). pi-vcc / dual-instance stacking was RULED OUT by repro (a
+//           stacked session dropped fine, 17,102 msgs pruned). Fix: persist the
+//           drop high-water (sessionFp / safe_drop_before / stored_through) on
+//           globalThis — the ONLY scope that survives the jiti re-eval, where
+//           the tools#44 dual-instance sentinel already lives — keyed by the
+//           persistent conv-id, and RESTORE it (in `session_start` and, as a
+//           request-path backstop, in `context`) when the conv-id matches, so a
+//           branch-nulled fp self-heals on turn 1. Keying by conv-id makes the
+//           distinction automatic: a genuinely new conversation, a fork to a
+//           NEW session id, or a session_tree branch with its own `:leafId`
+//           conv-id has no cache entry → the clean reset stands. New
+//           `drop_state_restored` telemetry marks the self-heal. The 2.4.0
+//           stale-window self-heal (which now also clears the cached high-water,
+//           so a post-heal reload can't re-freeze) and the 2.5.2 conv-id drop
+//           are preserved.
+const EXTENSION_VERSION = "2.5.3";
 
 // ── Provider definition (folded in from the former configs/models.json) ─────
 // Declaring the full provider config inline lets this extension be a
@@ -332,6 +364,118 @@ function releaseDualInstanceSentinel(activationId: string): void {
     }
   } catch {
     // never break shutdown on guard bookkeeping
+  }
+}
+
+// ── Cross-activation drop-state cache (2.5.3) ───────────────────────────────
+// A pi branch/fork/resume/reload re-evaluates this module under jiti
+// (`moduleCache:false`), so the module-scoped `state` below is recreated fresh
+// with `sessionFp: null` / `safeDropBefore: 0` on EVERY such event — the
+// session_start reset is just the in-process analogue of that. The wire
+// conv-id PERSISTS across the re-eval (process.env survives it), so the gateway
+// keeps the same session_fp and keeps emitting `safe_drop_before`; without a
+// way to carry the drop high-water across the re-eval the client skips every
+// drop with `no_session_fp` and the window runs away (Tom 2026-06-14).
+//
+// globalThis is the ONLY scope that survives the re-eval (same reason the
+// tools#44 dual-instance sentinel lives there). We stash the drop high-water
+// here keyed by the persistent conv-id, so the next activation can RESTORE it
+// when the conv-id matches. Keying by conv-id is what distinguishes a
+// continuation (resume/reload of the same conversation → restore) from a
+// genuinely new conversation, a fork to a NEW session id, or a session_tree
+// branch with its own `:leafId` conv-id (no cache entry → clean reset).
+const DROP_STATE_CACHE_KEY = "__NEURALWATT_MCR_DROP_STATE_V1__";
+
+// Bound memory: retain at most this many conversations, evicting the
+// least-recently-updated. A coding session touches one conv-id at a time, so
+// this is generous headroom, not a working-set limit.
+const DROP_STATE_MAX_ENTRIES = 64;
+
+// A conversation whose high-water hasn't been refreshed in this long is treated
+// as ended: a resume after it won't restore a stale high-water (the gateway may
+// have evicted the MCR session anyway, and the first response re-establishes it).
+const DROP_STATE_TTL_MS = 24 * 60 * 60 * 1000;
+
+interface PersistedDropState {
+  sessionFp: string | null;
+  safeDropBefore: number;
+  storedThrough: number;
+  /** ms epoch of the last refresh — drives TTL expiry and LRU eviction. */
+  ts: number;
+}
+
+// The conv-id → drop-state map on globalThis, created on first use. Returns
+// null only if globalThis is frozen/sealed (fail-open: the drop simply behaves
+// as pre-2.5.3, never breaks).
+function dropStateMap(): Record<string, PersistedDropState> | null {
+  try {
+    const g = globalThis as unknown as Record<string, unknown>;
+    let map = g[DROP_STATE_CACHE_KEY] as
+      | Record<string, PersistedDropState>
+      | undefined;
+    if (!map || typeof map !== "object") {
+      map = {};
+      g[DROP_STATE_CACHE_KEY] = map;
+    }
+    return map;
+  } catch {
+    return null;
+  }
+}
+
+// Read this conversation's persisted drop high-water, or null if absent/expired.
+function loadPersistedDropState(convId: string): PersistedDropState | null {
+  if (!convId) return null;
+  const map = dropStateMap();
+  if (!map) return null;
+  const entry = map[convId];
+  if (!entry) return null;
+  if (Date.now() - entry.ts > DROP_STATE_TTL_MS) {
+    delete map[convId];
+    return null;
+  }
+  return entry;
+}
+
+// Persist this conversation's drop high-water so a later branch/resume/reload
+// can restore it. Evicts the least-recently-updated entries past the cap.
+function savePersistedDropState(
+  convId: string,
+  next: {
+    sessionFp: string | null;
+    safeDropBefore: number;
+    storedThrough: number;
+  },
+): void {
+  if (!convId) return;
+  const map = dropStateMap();
+  if (!map) return;
+  try {
+    map[convId] = { ...next, ts: Date.now() };
+    const keys = Object.keys(map);
+    if (keys.length > DROP_STATE_MAX_ENTRIES) {
+      keys
+        .sort((a, b) => (map[a].ts ?? 0) - (map[b].ts ?? 0))
+        .slice(0, keys.length - DROP_STATE_MAX_ENTRIES)
+        .forEach((k) => delete map[k]);
+    }
+  } catch {
+    // never break a handler on cache bookkeeping
+  }
+}
+
+// Drop this conversation's persisted high-water (used by the stale-window
+// self-heal: it intentionally sends the full history so the server
+// re-establishes stored_through; a restore of the pre-heal high-water on a
+// subsequent reload would re-freeze the window).
+function clearPersistedDropState(convId: string): void {
+  if (!convId) return;
+  const map = dropStateMap();
+  if (!map) return;
+  try {
+    delete map[convId];
+  } catch {
+    // never break a handler on cache bookkeeping
   }
 }
 
@@ -631,6 +775,39 @@ function isWellFormedConversationId(value: string): boolean {
 function conversationIdActive(): boolean {
   const id = process.env[CONV_ID_ENV];
   return typeof id === "string" && isWellFormedConversationId(id);
+}
+
+// The conv-id currently on the wire (the live value of CONV_ID_ENV). Used as
+// the cache key for the cross-activation drop-state restore (2.5.3). Returns
+// "" when unset, which the cache helpers treat as "no key" (no read/write).
+function currentConversationId(): string {
+  const id = process.env[CONV_ID_ENV];
+  return typeof id === "string" ? id : "";
+}
+
+// Re-establish the module-scoped drop high-water from the globalThis cache for
+// `convId`, if a usable entry exists. Returns the restored snapshot (so the
+// caller can log it) or null. Only restores an ACTIONABLE high-water — a cached
+// sessionFp or a positive safe_drop_before; a bare zero would just fall through
+// to the normal first-response path. This is the branch self-heal: after a
+// jiti re-eval nulled `state`, a matching conv-id restores fp + safe_drop_before
+// so the very next `context` keeps pruning instead of skipping forever
+// (Tom 2026-06-14). See the cache block above for why this is correct and safe.
+function restoreDropStateFromCache(convId: string): PersistedDropState | null {
+  const cached = loadPersistedDropState(convId);
+  if (!cached) return null;
+  if (!cached.sessionFp && cached.safeDropBefore <= 0) return null;
+  state.sessionFp = cached.sessionFp;
+  state.safeDropBefore = cached.safeDropBefore;
+  state.storedThrough = cached.storedThrough;
+  if (cached.sessionFp) {
+    state.lastMcrMeta = {
+      session_fp: cached.sessionFp,
+      stored_through: cached.storedThrough,
+      safe_drop_before: cached.safeDropBefore,
+    };
+  }
+  return cached;
 }
 
 // Per-process fallback id. Generated lazily so it stays stable across
@@ -1074,7 +1251,7 @@ export default function (pi: ExtensionAPI) {
     updateStatusBar(ctx);
   }
 
-  pi.on("session_start", async (_event, ctx) => {
+  pi.on("session_start", async (event, ctx) => {
     touchDualInstanceSentinel(activationId);
     // #4111: clear the active branch suffix at session boot so a fresh pi
     // invocation always starts with the bare session id on the wire. Branch
@@ -1135,6 +1312,40 @@ export default function (pi: ExtensionAPI) {
     // within one `pi` invocation. Nulling it on session_start causes
     // conversation ID thrashing during double-start races (the root cause
     // of the "two brains" MCR session_fp flip).
+
+    // 2.5.3: re-establish the drop high-water across a pi BRANCH/fork/resume/
+    // reload. jiti re-evaluated this module (the reset above is the in-process
+    // analogue of that wipe), but the conv-id persisted, so the gateway still
+    // holds this conversation's fp + safe_drop_before. Restoring from the
+    // globalThis cache (keyed by the persistent conv-id) lets the very next
+    // `context` keep honoring safe_drop_before instead of skipping with
+    // no_session_fp until a fresh response re-establishes it — the runaway Tom
+    // hit (2026-06-14). A genuinely new conversation (or a fork to a NEW
+    // session id, or a session_tree branch with its own `:leafId` conv-id) has
+    // NO cache entry for this conv-id → the clean reset above stands.
+    const restoredAtStart = restoreDropStateFromCache(conversationId);
+    if (restoredAtStart) {
+      const reason =
+        typeof (event as { reason?: unknown })?.reason === "string"
+          ? (event as { reason: string }).reason
+          : null;
+      nwlog("drop_state_restored", {
+        source: "session_start",
+        reason,
+        conversation_id_prefix: conversationId.slice(0, 8),
+        session_fp: restoredAtStart.sessionFp,
+        safe_drop_before: restoredAtStart.safeDropBefore,
+        stored_through: restoredAtStart.storedThrough,
+      });
+      console.error(
+        `[neuralwatt-mcr] DROP STATE RESTORED after branch/${reason ?? "?"} — ` +
+          `conv ${conversationId.slice(0, 8)} fp ` +
+          `${restoredAtStart.sessionFp ?? "-"} safe_drop_before=` +
+          `${restoredAtStart.safeDropBefore}; the window keeps pruning across ` +
+          `the branch (neuralwatt-tools branch-session-fp fix).`,
+      );
+    }
+
     ctx.ui.setStatus(MCR_STATUS_KEY, "");
     ctx.ui.setStatus(ENERGY_STATUS_KEY, "");
   });
@@ -1203,6 +1414,14 @@ export default function (pi: ExtensionAPI) {
       state.safeDropBefore = mcrFromHeaders.safe_drop_before;
       state.storedThrough = mcrFromHeaders.stored_through;
       state.lastMcrMeta = mcrFromHeaders;
+      // 2.5.3: persist the drop high-water under the wire conv-id so a later
+      // branch/fork/resume/reload (which re-evaluates this module under jiti
+      // and nulls `state`) can restore it and keep honoring safe_drop_before.
+      savePersistedDropState(currentConversationId(), {
+        sessionFp: state.sessionFp,
+        safeDropBefore: state.safeDropBefore,
+        storedThrough: state.storedThrough,
+      });
     }
 
     updateStatusBar(ctx);
@@ -1240,6 +1459,13 @@ export default function (pi: ExtensionAPI) {
       state.safeDropBefore = mcrFromBody.safe_drop_before;
       state.storedThrough = mcrFromBody.stored_through;
       state.lastMcrMeta = mcrFromBody;
+      // 2.5.3: persist the drop high-water so a later branch/resume/reload can
+      // restore it (see the after_provider_response note + the cache block).
+      savePersistedDropState(currentConversationId(), {
+        sessionFp: state.sessionFp,
+        safeDropBefore: state.safeDropBefore,
+        storedThrough: state.storedThrough,
+      });
     }
 
     const energy = extractEnergyFromBody(msg);
@@ -1280,6 +1506,36 @@ export default function (pi: ExtensionAPI) {
     // about MCR sessions only. Behaviour for MCR models is unchanged.
     if (!isMCRModel(modelId)) {
       return;
+    }
+    // 2.5.3 branch self-heal (request-path backstop). If a pi branch/fork/
+    // resume/reload re-evaluated this module and nulled `state.sessionFp`, but
+    // this conversation's drop high-water is cached under the persistent
+    // conv-id, restore it here — BEFORE the no_session_fp skip — so the drop
+    // keeps honoring the server's safe_drop_before instead of skipping forever
+    // and letting the window run away (Tom 2026-06-14). In the normal flow
+    // session_start already restored it, so this fires only on paths where it
+    // didn't (e.g. a context event without a preceding session_start). A
+    // genuinely new conv-id has no cache entry → no restore → the legitimate
+    // first-turn no_session_fp skip below still applies.
+    if (!state.sessionFp) {
+      const convId = currentConversationId();
+      const restored = restoreDropStateFromCache(convId);
+      if (restored) {
+        nwlog("drop_state_restored", {
+          source: "context",
+          conversation_id_prefix: convId.slice(0, 8),
+          session_fp: restored.sessionFp,
+          safe_drop_before: restored.safeDropBefore,
+          stored_through: restored.storedThrough,
+        });
+        console.error(
+          `[neuralwatt-mcr] DROP STATE RESTORED after branch/resume — conv ` +
+            `${convId.slice(0, 8)} fp ${restored.sessionFp ?? "-"} ` +
+            `safe_drop_before=${restored.safeDropBefore}; honoring the server ` +
+            `drop across the branch (neuralwatt-tools branch-session-fp fix).`,
+        );
+        updateStatusBar(ctx);
+      }
     }
     if (!state.sessionFp) {
       nwlog("context_skip", {
@@ -1401,6 +1657,11 @@ export default function (pi: ExtensionAPI) {
       state.prevWindowSig = null;
       state.prevLocalLen = 0;
       state.staleWindowRepeats = 0;
+      // 2.5.3: drop the persisted high-water for this conversation too. We're
+      // intentionally sending the full history so the server re-establishes
+      // stored_through; if a later branch/reload restored the pre-heal
+      // high-water it would re-freeze the very window we just healed.
+      clearPersistedDropState(currentConversationId());
       updateStatusBar(ctx);
       // No message mutation — the full local history goes out on this request.
       return;

--- a/plugins/pi/package-lock.json
+++ b/plugins/pi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neuralwatt/pi-mcr-extension",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neuralwatt/pi-mcr-extension",
-      "version": "2.5.2",
+      "version": "2.5.3",
       "license": "MIT",
       "devDependencies": {
         "typebox": "^1.1.38",

--- a/plugins/pi/package.json
+++ b/plugins/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neuralwatt/pi-mcr-extension",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "Neuralwatt MCR extension for Pi — 1M virtual context via server-side compaction",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Problem

A pi **branch/fork/resume/reload** re-evaluates the extension module under jiti (`moduleCache:false` — see pi-coding-agent `extensions/loader.js` `loadExtensionModule`), recreating the module-scoped `state` fresh with `sessionFp=null` / `safeDropBefore=0` on **every** branch. The wire `X-NW-Conversation-ID` **persists** across the re-eval (process.env survives it and `resolveConversationId` re-derives the same pi session id), so the gateway keeps the **same** `session_fp` and keeps emitting `safe_drop_before` — but the freshly-wiped client hit `if (!state.sessionFp) return` (`context_skip reason=no_session_fp`) and **never pruned**, so the client context window ran away.

### Evidence (dogfooder Tom, 2026-06-14, ext 2.5.2)

- Branched session (`pi-session-branch`, `isPrimaryBranch:true/false`) looped to **1.36M client-window tokens**.
- Server emitted `safe_drop_before=615` the whole time; the client never dropped.
- Client log showed repeated `{"event":"session_shutdown","final_session_fp":null}` + `{"event":"context_skip","reason":"no_session_fp"}`.
- A fresh (non-branched) session dropped fine (stable `session_fp`, `conversation_id_attached` every turn).
- **pi-vcc / dual-instance stacking was ruled out** by repro — a stacked-extension session dropped fine (17,102 messages pruned).

## Confirmed mechanism (code, not speculation)

1. `SessionStartEvent.reason` is `"startup" | "reload" | "new" | "resume" | "fork"` — a **branch fires `session_start` with `reason:"fork"`** (and `session_shutdown reason:"fork"` first). The `session_start` handler **ignores `reason`** and unconditionally nulls `state.sessionFp` / `state.safeDropBefore`.
2. The `context` handler gates the **entire** drop on `if (!state.sessionFp) { context_skip no_session_fp; return; }`.
3. `reload()` → `session_shutdown` → `resourceLoader.reload()` → `loadExtensions` re-imports the module with jiti `moduleCache:false`, so module-scoped `state` (and `lastSessionId`) reset fresh on **every** branch/fork/resume/reload — independent of the handler's own reset, and **unavoidable in module scope**. `globalThis` is the only scope that survives (which is exactly why the tools#44 dual-instance sentinel lives there).

So a branch nulls the fp, the conv-id persists, the server keeps offering `safe_drop_before`, and the client refuses to act on it — the window runs away.

## Fix

Persist the drop high-water (`sessionFp` / `safe_drop_before` / `stored_through`) on **globalThis** (survives the jiti re-eval) keyed by the **persistent conv-id**, and **restore** it when the conv-id matches:

- **`session_start`** restores after its reset (primary), logging `drop_state_restored source=session_start reason=<fork|resume|reload>`.
- **`context`** restores as a request-path backstop before the `no_session_fp` skip, so the drop self-heals even on paths where `session_start` didn't.
- **`after_provider_response` / `message_end`** write the high-water to the cache.
- The **2.4.0 stale-window self-heal** now also **clears** the cached high-water (a post-heal reload must not restore the pre-heal value and re-freeze the window).

Keying by conv-id makes the distinction automatic: a genuinely new conversation, a fork to a **new** session id, or a `session_tree` branch with its own `:leafId` conv-id has **no cache entry → clean reset preserved**. Cache is bounded (64 entries, LRU) with a 24h TTL. The 2.5.2 conv-id-mode drop is untouched.

New `drop_state_restored` telemetry lets us confirm the self-heal in prod.

## Tests

Extends the vitest suite (`plugins/pi`, all 40 pass):

- A branch (`session_shutdown reason:fork` → re-activate → `session_start reason:fork`, conv-id persists) **still computes a non-empty drop on the next turn** — no `no_session_fp` anywhere in the flow.
- A genuinely new conversation after a branch **resets cleanly** (no cross-conversation restore; first turn legitimately `no_session_fp`).
- The **context backstop** restores the fp when `session_start` didn't.
- An **expired (>TTL)** cached high-water is not restored.
- The **stale-window self-heal clears** the cached high-water.

Existing drop / stale-window / dual-instance / conv-id tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)