### PR TITLE
docs: add Oh My Pi and Pi integration recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Get your API key from [portal.neuralwatt.com](https://portal.neuralwatt.com), th
 | [Open WebUI](recipes/open-webui/) | Self-hosted ChatGPT-style web UI | [Setup guide](recipes/open-webui/README.md) |
 | [OpenCode](recipes/opencode/) | AI coding agent CLI | [Setup guide](recipes/opencode/README.md) |
 | [Oh My Pi](recipes/oh-my-pi/) | Terminal AI coding agent with sub-agents, LSP, and memory | [Setup guide](recipes/oh-my-pi/README.md) |
+| [Pi](recipes/pi/) | Minimal terminal coding agent with Neuralwatt models | [Setup guide](recipes/pi/README.md) |
 | [llm plugin](plugins/llm-neuralwatt/) | Use Neuralwatt with [simonw/llm](https://llm.datasette.io/) CLI | [Setup guide](plugins/llm-neuralwatt/README.md) |
 | [Pi MCR extension](plugins/pi/) *(private beta)* | Unlock 1M virtual context in [Pi](https://pi.dev) via Neuralwatt MCR | [Setup guide](plugins/pi/README.md) |
 | [Build your own MCR client](docs/mcr-context-drop-client-protocol.md) | Integrate MCR context management into any OpenAI-/Anthropic-compatible client | [Protocol spec](docs/mcr-context-drop-client-protocol.md) |
@@ -69,6 +70,7 @@ neuralwatt-tools/
     ├── hermes/              # Nous Research Hermes Agent setup
     ├── open-webui/          # Self-hosted ChatGPT-style web UI
     ├── oh-my-pi/            # Oh My Pi terminal agent setup
+    ├── pi/                  # Pi terminal agent setup
     ├── opencode/            # AI coding agent CLI setup
     ├── neovim/              # Energy monitor + AI plugin configs
     └── tmux/                # Statusline integration

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Get your API key from [portal.neuralwatt.com](https://portal.neuralwatt.com), th
 | [Crush](recipes/crush/) | Terminal-based AI coding assistant with auto-discovery | [Setup guide](recipes/crush/README.md) |
 | [Open WebUI](recipes/open-webui/) | Self-hosted ChatGPT-style web UI | [Setup guide](recipes/open-webui/README.md) |
 | [OpenCode](recipes/opencode/) | AI coding agent CLI | [Setup guide](recipes/opencode/README.md) |
+| [Oh My Pi](recipes/oh-my-pi/) | Terminal AI coding agent with sub-agents, LSP, and memory | [Setup guide](recipes/oh-my-pi/README.md) |
 | [llm plugin](plugins/llm-neuralwatt/) | Use Neuralwatt with [simonw/llm](https://llm.datasette.io/) CLI | [Setup guide](plugins/llm-neuralwatt/README.md) |
 | [Pi MCR extension](plugins/pi/) *(private beta)* | Unlock 1M virtual context in [Pi](https://pi.dev) via Neuralwatt MCR | [Setup guide](plugins/pi/README.md) |
 | [Build your own MCR client](docs/mcr-context-drop-client-protocol.md) | Integrate MCR context management into any OpenAI-/Anthropic-compatible client | [Protocol spec](docs/mcr-context-drop-client-protocol.md) |
@@ -67,6 +68,7 @@ neuralwatt-tools/
     ├── crush/              # AI coding agent CLI with auto-discovery
     ├── hermes/              # Nous Research Hermes Agent setup
     ├── open-webui/          # Self-hosted ChatGPT-style web UI
+    ├── oh-my-pi/            # Oh My Pi terminal agent setup
     ├── opencode/            # AI coding agent CLI setup
     ├── neovim/              # Energy monitor + AI plugin configs
     └── tmux/                # Statusline integration

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Get your API key from [portal.neuralwatt.com](https://portal.neuralwatt.com), th
 | [Open WebUI](recipes/open-webui/) | Self-hosted ChatGPT-style web UI | [Setup guide](recipes/open-webui/README.md) |
 | [OpenCode](recipes/opencode/) | AI coding agent CLI | [Setup guide](recipes/opencode/README.md) |
 | [Oh My Pi](recipes/oh-my-pi/) | Terminal AI coding agent with sub-agents, LSP, and memory | [Setup guide](recipes/oh-my-pi/README.md) |
-| [Pi](recipes/pi/) | Minimal terminal coding agent with Neuralwatt models | [Setup guide](recipes/pi/README.md) |
+| [Pi](recipes/pi/) | Minimal terminal coding agent | [Setup guide](recipes/pi/README.md) |
 | [llm plugin](plugins/llm-neuralwatt/) | Use Neuralwatt with [simonw/llm](https://llm.datasette.io/) CLI | [Setup guide](plugins/llm-neuralwatt/README.md) |
 | [Pi MCR extension](plugins/pi/) *(private beta)* | Unlock 1M virtual context in [Pi](https://pi.dev) via Neuralwatt MCR | [Setup guide](plugins/pi/README.md) |
 | [Build your own MCR client](docs/mcr-context-drop-client-protocol.md) | Integrate MCR context management into any OpenAI-/Anthropic-compatible client | [Protocol spec](docs/mcr-context-drop-client-protocol.md) |

--- a/recipes/oh-my-pi/README.md
+++ b/recipes/oh-my-pi/README.md
@@ -1,0 +1,133 @@
+# Oh My Pi with Neuralwatt
+
+[Oh My Pi](https://github.com/can1357/oh-my-pi) (omp) is a terminal AI coding agent built on the Pi framework with additional built-in tools (sub-agents, web search, browser automation, LSP) and a SQLite-backed memory system. Neuralwatt models are not included in omp's built-in catalog, so you add them via `models.yml`.
+
+## Prerequisites
+
+- [Neuralwatt API key](https://portal.neuralwatt.com)
+- Oh My Pi v14.5+ ([install guide](https://github.com/can1357/oh-my-pi#installation))
+
+## Install
+
+```bash
+# Homebrew (macOS)
+brew install can1357/tap/oh-my-pi
+
+# npm
+npm install -g @oh-my-pi/cli
+```
+
+## Setup
+
+**1. Export your API key** (add to `~/.zshrc` or `~/.bashrc`):
+
+```bash
+export NEURALWATT_API_KEY="your-api-key-here"
+```
+
+**2. Create** `~/.omp/agent/models.yml`:
+
+```yaml
+providers:
+  neuralwatt:
+    baseUrl: https://api.neuralwatt.com/v1
+    api: openai-completions
+    apiKey: NEURALWATT_API_KEY
+    authHeader: true
+    compat:
+      supportsDeveloperRole: false
+      supportsReasoningEffort: false
+    models:
+      - id: Qwen/Qwen3.6-35B-A3B
+        name: Qwen3.6 35B
+        reasoning: true
+        input: [text, image]
+        contextWindow: 131056
+        maxTokens: 32768
+        cost: { input: 0.05, output: 0.10, cacheRead: 0, cacheWrite: 0 }
+      - id: moonshotai/Kimi-K2.6
+        name: Kimi K2.6
+        reasoning: true
+        input: [text, image]
+        contextWindow: 262128
+        maxTokens: 65536
+        cost: { input: 0.69, output: 3.22, cacheRead: 0, cacheWrite: 0 }
+      - id: moonshotai/Kimi-K2.5
+        name: Kimi K2.5
+        reasoning: true
+        input: [text, image]
+        contextWindow: 262128
+        maxTokens: 65536
+        cost: { input: 0.52, output: 2.59, cacheRead: 0, cacheWrite: 0 }
+      - id: zai-org/GLM-5.1-FP8
+        name: GLM-5.1
+        reasoning: true
+        input: [text]
+        contextWindow: 202736
+        maxTokens: 32768
+        cost: { input: 1.10, output: 3.60, cacheRead: 0, cacheWrite: 0 }
+      - id: Qwen/Qwen3.5-397B-A17B-FP8
+        name: Qwen3.5 397B
+        reasoning: true
+        input: [text]
+        contextWindow: 262128
+        maxTokens: 65536
+        cost: { input: 0.69, output: 4.14, cacheRead: 0, cacheWrite: 0 }
+      - id: MiniMaxAI/MiniMax-M2.5
+        name: MiniMax M2.5
+        reasoning: true
+        input: [text]
+        contextWindow: 196592
+        maxTokens: 49152
+        cost: { input: 0.35, output: 1.38, cacheRead: 0, cacheWrite: 0 }
+      - id: mistralai/Devstral-Small-2-24B-Instruct-2512
+        name: Devstral 24B
+        reasoning: false
+        input: [text, image]
+        contextWindow: 262128
+        maxTokens: 65536
+        cost: { input: 0.12, output: 0.35, cacheRead: 0, cacheWrite: 0 }
+      - id: openai/gpt-oss-20b
+        name: GPT-OSS 20B
+        reasoning: true
+        input: [text]
+        contextWindow: 16368
+        maxTokens: 4096
+        cost: { input: 0.03, output: 0.16, cacheRead: 0, cacheWrite: 0 }
+```
+
+This file replaces the built-in model list for the `neuralwatt` provider. omp loads it on startup and also re-reads it when you open `/model` during a session.
+
+## Run
+
+```bash
+omp --model neuralwatt/moonshotai/Kimi-K2.6
+```
+
+Or launch omp and switch models with `/model` or `Ctrl+L`.
+
+## Available Models
+
+Browse the full catalog at [portal.neuralwatt.com](https://portal.neuralwatt.com), or query the API:
+
+```bash
+curl -s -H "Authorization: Bearer $NEURALWATT_API_KEY" \
+  https://api.neuralwatt.com/v1/models | jq '.data[].id'
+```
+
+## Skills: Reuse Your Pi Skills
+
+Oh My Pi auto-discovers skills from `~/.pi/agent/skills/` (the `skills.enablePiUser` setting defaults to `true`). If you have Neuralwatt-specific skills there (e.g. from [neuralwatt-claude-skills](https://github.com/neuralwatt/neuralwatt-claude-skills)), they work without extra configuration.
+
+To add skill directories that omp doesn't scan by default:
+
+```bash
+omp config set skills.customDirectories '["~/src/neuralwatt-claude-skills"]'
+```
+
+## Configuration Notes
+
+- The `apiKey` field accepts a bare environment variable name (e.g., `NEURALWATT_API_KEY`). omp resolves it at runtime. You can also hardcode the key value directly, but using an env var avoids storing secrets in a dotfile.
+- `compat` replaces the built-in block wholesale per the DeepSeek integration model — it does not merge. If you need a model-specific compat override, include all fields in that model's `compat` block.
+- The `authHeader: true` setting tells omp to send `Authorization: Bearer <key>`. Neuralwatt requires this.
+- `supportsDeveloperRole: false` is required because Neuralwatt's OpenAI-compatible API rejects the `developer` role and expects `system`.

--- a/recipes/oh-my-pi/README.md
+++ b/recipes/oh-my-pi/README.md
@@ -117,12 +117,12 @@ curl -s -H "Authorization: Bearer $NEURALWATT_API_KEY" \
 
 ## Skills: Reuse Your Pi Skills
 
-Oh My Pi auto-discovers skills from `~/.pi/agent/skills/` (the `skills.enablePiUser` setting defaults to `true`). If you have Neuralwatt-specific skills there (e.g. from [neuralwatt-claude-skills](https://github.com/neuralwatt/neuralwatt-claude-skills)), they work without extra configuration.
+Oh My Pi auto-discovers skills from `~/.pi/agent/skills/` (the `skills.enablePiUser` setting defaults to `true`). If you have Neuralwatt-specific skills there, they work without extra configuration.
 
 To add skill directories that omp doesn't scan by default:
 
 ```bash
-omp config set skills.customDirectories '["~/src/neuralwatt-claude-skills"]'
+omp config set skills.customDirectories '["/path/to/your/skills"]'
 ```
 
 ## Configuration Notes

--- a/recipes/pi/README.md
+++ b/recipes/pi/README.md
@@ -1,0 +1,159 @@
+# Pi with Neuralwatt
+
+[Pi](https://pi.dev) is a minimal terminal coding agent. Extensions, skills, and prompt templates customize its behavior without modifying Pi internals. Neuralwatt models are not included in Pi's built-in catalog, so you add them via `models.json`.
+
+## Prerequisites
+
+- [Neuralwatt API key](https://portal.neuralwatt.com)
+- Pi v0.72+ ([install guide](https://pi.dev))
+
+## Install
+
+```bash
+# npm
+npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+
+# Or via the installer script
+curl -fsSL https://pi.dev/install.sh | sh
+```
+
+## Setup
+
+**1. Export your API key** (add to `~/.zshrc` or `~/.bashrc`):
+
+```bash
+export NEURALWATT_API_KEY="your-api-key-here"
+```
+
+**2. Create** `~/.pi/agent/models.json`:
+
+```json
+{
+  "providers": {
+    "neuralwatt": {
+      "baseUrl": "https://api.neuralwatt.com/v1",
+      "api": "openai-completions",
+      "apiKey": "$NEURALWATT_API_KEY",
+      "authHeader": true,
+      "compat": {
+        "supportsDeveloperRole": false,
+        "supportsReasoningEffort": false
+      },
+      "models": [
+        {
+          "id": "Qwen/Qwen3.6-35B-A3B",
+          "name": "Qwen3.6 35B",
+          "reasoning": true,
+          "input": ["text", "image"],
+          "contextWindow": 131056,
+          "maxTokens": 32768,
+          "cost": { "input": 0.05, "output": 0.10, "cacheRead": 0, "cacheWrite": 0 }
+        },
+        {
+          "id": "moonshotai/Kimi-K2.6",
+          "name": "Kimi K2.6",
+          "reasoning": true,
+          "input": ["text", "image"],
+          "contextWindow": 262128,
+          "maxTokens": 65536,
+          "cost": { "input": 0.69, "output": 3.22, "cacheRead": 0, "cacheWrite": 0 }
+        },
+        {
+          "id": "moonshotai/Kimi-K2.5",
+          "name": "Kimi K2.5",
+          "reasoning": true,
+          "input": ["text", "image"],
+          "contextWindow": 262128,
+          "maxTokens": 65536,
+          "cost": { "input": 0.52, "output": 2.59, "cacheRead": 0, "cacheWrite": 0 }
+        },
+        {
+          "id": "zai-org/GLM-5.1-FP8",
+          "name": "GLM-5.1",
+          "reasoning": true,
+          "input": ["text"],
+          "contextWindow": 202736,
+          "maxTokens": 32768,
+          "cost": { "input": 1.10, "output": 3.60, "cacheRead": 0, "cacheWrite": 0 }
+        },
+        {
+          "id": "Qwen/Qwen3.5-397B-A17B-FP8",
+          "name": "Qwen3.5 397B",
+          "reasoning": true,
+          "input": ["text"],
+          "contextWindow": 262128,
+          "maxTokens": 65536,
+          "cost": { "input": 0.69, "output": 4.14, "cacheRead": 0, "cacheWrite": 0 }
+        },
+        {
+          "id": "MiniMaxAI/MiniMax-M2.5",
+          "name": "MiniMax M2.5",
+          "reasoning": true,
+          "input": ["text"],
+          "contextWindow": 196592,
+          "maxTokens": 49152,
+          "cost": { "input": 0.35, "output": 1.38, "cacheRead": 0, "cacheWrite": 0 }
+        },
+        {
+          "id": "mistralai/Devstral-Small-2-24B-Instruct-2512",
+          "name": "Devstral 24B",
+          "reasoning": false,
+          "input": ["text", "image"],
+          "contextWindow": 262128,
+          "maxTokens": 65536,
+          "cost": { "input": 0.12, "output": 0.35, "cacheRead": 0, "cacheWrite": 0 }
+        },
+        {
+          "id": "openai/gpt-oss-20b",
+          "name": "GPT-OSS 20B",
+          "reasoning": true,
+          "input": ["text"],
+          "contextWindow": 16368,
+          "maxTokens": 4096,
+          "cost": { "input": 0.03, "output": 0.16, "cacheRead": 0, "cacheWrite": 0 }
+        }
+      ]
+    }
+  }
+}
+```
+
+This file creates the `neuralwatt` provider in Pi's model registry. It reloads each time you open `/model`, so you can edit it mid-session.
+
+## Run
+
+```bash
+pi --model neuralwatt/moonshotai/Kimi-K2.6
+```
+
+Or launch Pi and switch models with `/model` or `Ctrl+L`.
+
+## Available Models
+
+Browse the full catalog at [portal.neuralwatt.com](https://portal.neuralwatt.com), or query the API:
+
+```bash
+curl -s -H "Authorization: Bearer $NEURALWATT_API_KEY" \
+  https://api.neuralwatt.com/v1/models | jq '.data[].id'
+```
+
+## MCR: 1M Virtual Context
+
+For long-context sessions, install the [Neuralwatt MCR extension](../../plugins/pi/):
+
+```bash
+pi install npm:@neuralwatt/pi-mcr-extension
+```
+
+This adds MCR-backed models (`neuralwatt/kimi-k2.6-long`, `neuralwatt/glm-5.1-long`) with server-side compaction that gives you a 1M token virtual context window. See the [MCR extension docs](../../plugins/pi/README.md) for details.
+
+## Skills: Use Neuralwatt Skills with Pi
+
+If you have Neuralwatt-specific skills (e.g., from [neuralwatt-claude-skills](https://github.com/neuralwatt/neuralwatt-claude-skills)), place them in `~/.pi/agent/skills/` or `~/.agents/skills/` and Pi discovers them automatically at startup.
+
+## Configuration Notes
+
+- The `apiKey` field supports environment variable interpolation with `$ENV_VAR` or `${ENV_VAR}` syntax. It also supports shell command execution with `!command` for secrets managers (e.g., `"apiKey": "!op read 'op://vault/item/key'"`).
+- `authHeader: true` tells Pi to send `Authorization: Bearer <key>`, which Neuralwatt requires.
+- `supportsDeveloperRole: false` is required because Neuralwatt's OpenAI-compatible API rejects the `developer` role and expects `system`.
+- Per-model `compat` overrides merge with the provider-level `compat` when both are set, so you can add `supportsReasoningEffort: true` on a specific model without re-specifying the provider-level fields.

--- a/recipes/pi/README.md
+++ b/recipes/pi/README.md
@@ -147,6 +147,8 @@ pi install npm:@neuralwatt/pi-mcr-extension
 
 This adds MCR-backed models (`neuralwatt/kimi-k2.6-long`, `neuralwatt/glm-5.1-long`) with server-side compaction that gives you a 1M token virtual context window. See the [MCR extension docs](../../plugins/pi/README.md) for details.
 
+> **If you install the MCR extension**, remove the `neuralwatt` provider from `~/.pi/agent/models.json` (or delete the file entirely). The extension registers the `neuralwatt` provider itself, and a hand-edited `models.json` entry will shadow it, preventing the long-context aliases from appearing in `/model`.
+
 ## Configuration Notes
 
 - The `apiKey` field supports environment variable interpolation with `$ENV_VAR` or `${ENV_VAR}` syntax. It also supports shell command execution with `!command` for secrets managers (e.g., `"apiKey": "!op read 'op://vault/item/key'"`).

--- a/recipes/pi/README.md
+++ b/recipes/pi/README.md
@@ -149,7 +149,7 @@ This adds MCR-backed models (`neuralwatt/kimi-k2.6-long`, `neuralwatt/glm-5.1-lo
 
 ## Skills: Use Neuralwatt Skills with Pi
 
-If you have Neuralwatt-specific skills (e.g., from [neuralwatt-claude-skills](https://github.com/neuralwatt/neuralwatt-claude-skills)), place them in `~/.pi/agent/skills/` or `~/.agents/skills/` and Pi discovers them automatically at startup.
+If you have Neuralwatt-specific skills, place them in `~/.pi/agent/skills/` or `~/.agents/skills/` and Pi discovers them automatically at startup.
 
 ## Configuration Notes
 

--- a/recipes/pi/README.md
+++ b/recipes/pi/README.md
@@ -147,10 +147,6 @@ pi install npm:@neuralwatt/pi-mcr-extension
 
 This adds MCR-backed models (`neuralwatt/kimi-k2.6-long`, `neuralwatt/glm-5.1-long`) with server-side compaction that gives you a 1M token virtual context window. See the [MCR extension docs](../../plugins/pi/README.md) for details.
 
-## Skills: Use Neuralwatt Skills with Pi
-
-If you have Neuralwatt-specific skills, place them in `~/.pi/agent/skills/` or `~/.agents/skills/` and Pi discovers them automatically at startup.
-
 ## Configuration Notes
 
 - The `apiKey` field supports environment variable interpolation with `$ENV_VAR` or `${ENV_VAR}` syntax. It also supports shell command execution with `!command` for secrets managers (e.g., `"apiKey": "!op read 'op://vault/item/key'"`).


### PR DESCRIPTION
## Summary

- Add `recipes/oh-my-pi/README.md` with setup instructions for using Neuralwatt models with Oh My Pi (omp)
- Add `recipes/pi/README.md` with setup instructions for using Neuralwatt models with Pi
- Register both recipes in the main README table and directory tree

### Oh My Pi

Oh My Pi uses `~/.omp/agent/models.yml` (YAML) for custom providers. The recipe covers the YAML format, required compat fields, `apiKey` as env var name, and skill reuse from existing Pi skill directories.

### Pi

Pi uses `~/.pi/agent/models.json` (JSON) for custom providers. The recipe covers the JSON format with `$ENV_VAR` interpolation for API keys, per-model compat overrides, and links to the MCR extension for 1M virtual context.

## Test plan

- [x] `models.yml` format verified against DeepSeek's official Oh My Pi integration docs
- [x] `models.json` format verified against Pi's official models.md docs
- [x] All Neuralwatt models listed match the portal catalog
- [x] Recipe structure matches existing recipes (claude-code, crush, opencode)