### PR TITLE
feat(hermes): ship Neuralwatt provider plugin in recipe

### DIFF
--- a/recipes/hermes/README.md
+++ b/recipes/hermes/README.md
@@ -44,6 +44,8 @@ Then add your key to `~/.hermes/.env`:
 NEURALWATT_API_KEY=your-api-key-here
 ```
 
+> **Upgrading from the old recipe?** Earlier versions of this guide pointed `OPENAI_API_KEY` and `OPENAI_BASE_URL` at Neuralwatt. Remove both from `~/.hermes/.env` — leaving `OPENAI_BASE_URL` set can misroute Hermes' OpenAI and OpenRouter fallbacks.
+
 Verify the install:
 
 ```bash
@@ -62,14 +64,14 @@ You can swap models mid-session with `/model`. The picker autocompletes the Neur
 
 ## Available Models
 
-The `/model` picker lists the live catalog. To browse it outside Hermes, see [portal.neuralwatt.com](https://portal.neuralwatt.com) or query the API directly:
+The `/model` picker lists the live catalog. To browse it outside Hermes, see [portal.neuralwatt.com](https://portal.neuralwatt.com) or query the API directly (the key lives in `~/.hermes/.env`, so `export NEURALWATT_API_KEY=...` in your shell first):
 
 ```bash
 curl -s -H "Authorization: Bearer $NEURALWATT_API_KEY" \
   https://api.neuralwatt.com/v1/models | jq '.data[].id'
 ```
 
-Most model IDs are bare and lowercase (for example `glm-5.2`, `kimi-k2.7-code`, `qwen3.5-397b`); a few are slash-form (for example `neuralwatt/kimi-k2.6-long`). Use the exact IDs returned by `/v1/models`.
+Model IDs are bare and lowercase (for example `glm-5.2`, `kimi-k2.7-code`, `qwen3.5-397b`). Use the exact IDs returned by `/v1/models` for your key.
 
 ## Messaging Gateway
 

--- a/recipes/hermes/README.md
+++ b/recipes/hermes/README.md
@@ -18,25 +18,31 @@ The installer creates `~/.hermes/` with `config.yaml`, `.env`, and the agent sou
 
 ## Setup
 
-Hermes treats any non-blessed OpenAI-compatible endpoint as a `custom` provider. Two small edits wire Neuralwatt in.
+Hermes discovers user-installed provider plugins from `~/.hermes/plugins/model-providers/<name>/`. This recipe ships a small Neuralwatt provider plugin (two files) that registers Neuralwatt as a first-class provider — so it appears in `hermes status` and the `/model` picker with the live model catalog, and uses its own `NEURALWATT_API_KEY` instead of hijacking the OpenAI environment variables.
 
-Edit `~/.hermes/config.yaml` and set the `model` block:
+Install the plugin:
+
+```bash
+mkdir -p ~/.hermes/plugins/model-providers/neuralwatt
+curl -fsSL https://raw.githubusercontent.com/neuralwatt/neuralwatt-tools/main/recipes/hermes/plugin/__init__.py \
+  -o ~/.hermes/plugins/model-providers/neuralwatt/__init__.py
+curl -fsSL https://raw.githubusercontent.com/neuralwatt/neuralwatt-tools/main/recipes/hermes/plugin/plugin.yaml \
+  -o ~/.hermes/plugins/model-providers/neuralwatt/plugin.yaml
+```
+
+Point Hermes at Neuralwatt in `~/.hermes/config.yaml`:
 
 ```yaml
 model:
-  default: "moonshotai/Kimi-K2.5"
-  provider: "custom"
-  base_url: "https://api.neuralwatt.com/v1"
+  default: glm-5.2
+  provider: neuralwatt
 ```
 
-Then append your key to `~/.hermes/.env`:
+Then add your key to `~/.hermes/.env`:
 
 ```bash
-OPENAI_API_KEY=your-api-key-here
-OPENAI_BASE_URL=https://api.neuralwatt.com/v1
+NEURALWATT_API_KEY=your-api-key-here
 ```
-
-Hermes reads `OPENAI_API_KEY` and `OPENAI_BASE_URL` when the provider is `custom`.
 
 Verify the install:
 
@@ -44,22 +50,26 @@ Verify the install:
 hermes doctor
 ```
 
+`hermes doctor` reports Neuralwatt as configured and probes `https://api.neuralwatt.com/v1/models`.
+
 ## Run
 
 ```bash
 hermes
 ```
 
-You can swap models mid-session with `/model <model-id>`. Hermes won't autocomplete the Neuralwatt catalog, so type the full model ID manually (for example `/model Qwen/Qwen3.5-397B-A17B-FP8`).
+You can swap models mid-session with `/model`. The picker autocompletes the Neuralwatt catalog, which the plugin live-fetches from `https://api.neuralwatt.com/v1/models` — so newly released models appear without any plugin update.
 
 ## Available Models
 
-Browse the full catalog at [portal.neuralwatt.com](https://portal.neuralwatt.com), or query the API directly:
+The `/model` picker lists the live catalog. To browse it outside Hermes, see [portal.neuralwatt.com](https://portal.neuralwatt.com) or query the API directly:
 
 ```bash
 curl -s -H "Authorization: Bearer $NEURALWATT_API_KEY" \
   https://api.neuralwatt.com/v1/models | jq '.data[].id'
 ```
+
+Model IDs are bare and lowercase (for example `glm-5.2`, `kimi-k2.7-code`, `qwen3.5-397b`).
 
 ## Messaging Gateway
 

--- a/recipes/hermes/README.md
+++ b/recipes/hermes/README.md
@@ -69,7 +69,7 @@ curl -s -H "Authorization: Bearer $NEURALWATT_API_KEY" \
   https://api.neuralwatt.com/v1/models | jq '.data[].id'
 ```
 
-Model IDs are bare and lowercase (for example `glm-5.2`, `kimi-k2.7-code`, `qwen3.5-397b`).
+Most model IDs are bare and lowercase (for example `glm-5.2`, `kimi-k2.7-code`, `qwen3.5-397b`); a few are slash-form (for example `neuralwatt/kimi-k2.6-long`). Use the exact IDs returned by `/v1/models`.
 
 ## Messaging Gateway
 

--- a/recipes/hermes/plugin/__init__.py
+++ b/recipes/hermes/plugin/__init__.py
@@ -1,0 +1,44 @@
+"""Neuralwatt provider profile for Hermes Agent.
+
+Install this directory into ``~/.hermes/plugins/model-providers/neuralwatt/``
+(see this recipe's README). It registers Neuralwatt as a first-class Hermes
+provider so it shows up in ``hermes status`` and the ``/model`` picker with a
+real model catalog, instead of an anonymous "Custom endpoint".
+
+Neuralwatt is OpenAI-compatible, so Hermes live-fetches the model catalog from
+``models_url`` (``{base_url}/models``). ``fallback_models`` is only consulted
+when that endpoint is unreachable, so the live API is always the source of
+truth and this list cannot silently go stale.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+neuralwatt = ProviderProfile(
+    name="neuralwatt",
+    aliases=("neural-watt", "neuralwatt-ai"),
+    display_name="Neuralwatt",
+    description="Neuralwatt — GLM, Kimi, Qwen via OpenAI-compatible API",
+    signup_url="https://portal.neuralwatt.com",
+    env_vars=("NEURALWATT_API_KEY", "NEURALWATT_BASE_URL"),
+    base_url="https://api.neuralwatt.com/v1",
+    models_url="https://api.neuralwatt.com/v1/models",
+    default_aux_model="glm-5.2-fast",
+    # Best-effort fallback only; the live /v1/models endpoint above is the
+    # source of truth and overrides this list whenever it is reachable.
+    fallback_models=(
+        "glm-5.2",
+        "glm-5.2-fast",
+        "glm-5.2-short",
+        "glm-5.2-short-fast",
+        "kimi-k2.6",
+        "kimi-k2.6-fast",
+        "kimi-k2.7-code",
+        "qwen3.5-397b",
+        "qwen3.5-397b-fast",
+        "qwen3.6-35b",
+        "qwen3.6-35b-fast",
+    ),
+)
+
+register_provider(neuralwatt)

--- a/recipes/hermes/plugin/__init__.py
+++ b/recipes/hermes/plugin/__init__.py
@@ -17,8 +17,9 @@ recipe README: ``default_aux_model`` below, and the README's ``config.yaml``
 ``model.default``. Both exist in the live catalog today; if either is ever
 retired upstream, refresh it here (aux) and in the README (default).
 
-``fallback_models`` is consulted only when ``models_url`` is unreachable. It is
-intentionally the public (unauthenticated) ``/v1/models`` set — the standard
+``fallback_models`` is consulted only when the live catalog fetch
+(``{base_url}/models``) is unreachable. It is intentionally the public
+(unauthenticated) ``/v1/models`` set — the standard
 tiers. Flex variants and any enrollment-gated models are deliberately omitted
 from this fallback; they still appear in the live picker for keys that can see
 them, so this gap is not drift to "fix".

--- a/recipes/hermes/plugin/__init__.py
+++ b/recipes/hermes/plugin/__init__.py
@@ -6,8 +6,11 @@ provider so it shows up in ``hermes status`` and the ``/model`` picker with a
 real model catalog, instead of an anonymous "Custom endpoint".
 
 Neuralwatt is OpenAI-compatible, so Hermes live-fetches the model *catalog*
-(the ``/model`` picker list) from ``models_url`` (``{base_url}/models``). The
-live API is the source of truth there, so the picker can't silently go stale.
+(the ``/model`` picker list) from ``{base_url}/models``. The live API is the
+source of truth there, so the picker can't silently go stale. We deliberately
+do not set ``models_url``: leaving it unset lets ``fetch_models()`` honor a
+``NEURALWATT_BASE_URL`` override (it derives the catalog endpoint from the
+effective base URL), so chat and the catalog can't point at different hosts.
 
 Two IDs are *not* covered by that live fetch and are pinned here / in the
 recipe README: ``default_aux_model`` below, and the README's ``config.yaml``
@@ -32,9 +35,8 @@ neuralwatt = ProviderProfile(
     signup_url="https://portal.neuralwatt.com",
     env_vars=("NEURALWATT_API_KEY", "NEURALWATT_BASE_URL"),
     base_url="https://api.neuralwatt.com/v1",
-    models_url="https://api.neuralwatt.com/v1/models",
     default_aux_model="glm-5.2-fast",
-    # Best-effort offline fallback only; the live /v1/models endpoint above is
+    # Best-effort offline fallback only; the live {base_url}/models endpoint is
     # the source of truth and overrides this list whenever it is reachable.
     # This is the public (unauthenticated) catalog — standard tiers, no flex.
     fallback_models=(

--- a/recipes/hermes/plugin/__init__.py
+++ b/recipes/hermes/plugin/__init__.py
@@ -5,10 +5,20 @@ Install this directory into ``~/.hermes/plugins/model-providers/neuralwatt/``
 provider so it shows up in ``hermes status`` and the ``/model`` picker with a
 real model catalog, instead of an anonymous "Custom endpoint".
 
-Neuralwatt is OpenAI-compatible, so Hermes live-fetches the model catalog from
-``models_url`` (``{base_url}/models``). ``fallback_models`` is only consulted
-when that endpoint is unreachable, so the live API is always the source of
-truth and this list cannot silently go stale.
+Neuralwatt is OpenAI-compatible, so Hermes live-fetches the model *catalog*
+(the ``/model`` picker list) from ``models_url`` (``{base_url}/models``). The
+live API is the source of truth there, so the picker can't silently go stale.
+
+Two IDs are *not* covered by that live fetch and are pinned here / in the
+recipe README: ``default_aux_model`` below, and the README's ``config.yaml``
+``model.default``. Both exist in the live catalog today; if either is ever
+retired upstream, refresh it here (aux) and in the README (default).
+
+``fallback_models`` is consulted only when ``models_url`` is unreachable. It is
+intentionally the public (unauthenticated) ``/v1/models`` set — the standard
+tiers. Flex variants and any enrollment-gated models are deliberately omitted
+from this fallback; they still appear in the live picker for keys that can see
+them, so this gap is not drift to "fix".
 """
 
 from providers import register_provider
@@ -16,7 +26,7 @@ from providers.base import ProviderProfile
 
 neuralwatt = ProviderProfile(
     name="neuralwatt",
-    aliases=("neural-watt", "neuralwatt-ai"),
+    aliases=("neural", "neural-watt", "neuralwatt-ai"),
     display_name="Neuralwatt",
     description="Neuralwatt — GLM, Kimi, Qwen via OpenAI-compatible API",
     signup_url="https://portal.neuralwatt.com",
@@ -24,8 +34,9 @@ neuralwatt = ProviderProfile(
     base_url="https://api.neuralwatt.com/v1",
     models_url="https://api.neuralwatt.com/v1/models",
     default_aux_model="glm-5.2-fast",
-    # Best-effort fallback only; the live /v1/models endpoint above is the
-    # source of truth and overrides this list whenever it is reachable.
+    # Best-effort offline fallback only; the live /v1/models endpoint above is
+    # the source of truth and overrides this list whenever it is reachable.
+    # This is the public (unauthenticated) catalog — standard tiers, no flex.
     fallback_models=(
         "glm-5.2",
         "glm-5.2-fast",

--- a/recipes/hermes/plugin/plugin.yaml
+++ b/recipes/hermes/plugin/plugin.yaml
@@ -1,0 +1,5 @@
+name: neuralwatt-provider
+kind: model-provider
+version: 1.0.0
+description: Neuralwatt
+author: Neuralwatt

--- a/recipes/hermes/plugin/plugin.yaml
+++ b/recipes/hermes/plugin/plugin.yaml
@@ -1,5 +1,5 @@
 name: neuralwatt-provider
 kind: model-provider
 version: 1.0.0
-description: Neuralwatt
+description: Neuralwatt provider profile (GLM, Kimi, Qwen via OpenAI-compatible API)
 author: Neuralwatt


### PR DESCRIPTION
## What

The Hermes recipe currently wires Neuralwatt in by pointing `OPENAI_API_KEY` / `OPENAI_BASE_URL` at our API. This PR replaces that with a proper Hermes **provider plugin** shipped in the recipe, and rewrites the README to install it.

Closes #52.

## Why the old approach was bad

Per #52, pointing the OpenAI env vars at us:

1. **Hijacks OpenAI's env vars** — users can't run real OpenAI alongside Neuralwatt; `hermes status` reports `OpenAI: (not set)`.
2. **Leaks `OPENAI_BASE_URL` globally** — Hermes checks it in multiple provider-resolution paths, interfering with OpenRouter / OpenAI fallback.
3. **No model catalog** — no `/model` autocomplete; users type full IDs by hand.
4. **Wrong model IDs** — the example used `Qwen/Qwen3.5-397B-A17B-FP8`; the live API returns bare lowercase IDs like `qwen3.5-397b`.
5. **Anonymous "Custom endpoint"** — no provider identity in status/picker/logs.

## What's in the PR

- `recipes/hermes/plugin/__init__.py` — a `ProviderProfile` registering `neuralwatt` (aliases `neural-watt`, `neuralwatt-ai`).
- `recipes/hermes/plugin/plugin.yaml` — the plugin manifest.
- `recipes/hermes/README.md` — install step (`curl` the two files into `~/.hermes/plugins/model-providers/neuralwatt/`), corrected `config.yaml`/`.env`, accurate model IDs.

## Staleness is designed out

The plugin sets `models_url=https://api.neuralwatt.com/v1/models`, so Hermes **live-fetches** the catalog — the live API is the source of truth and new models appear without a plugin update. `fallback_models` is consulted only when that endpoint is unreachable; it's seeded from the **public (unauthenticated)** `/v1/models` set — the 11 standard-tier models. Authenticated keys see more (flex variants, enrollment-gated models) and those surface automatically via live fetch, so the fallback is intentionally a curated non-flex subset, not a complete snapshot. `default_aux_model=glm-5.2-fast`. This is deliberately *not* a frozen hardcoded list — that staleness is exactly what #52 (and the upstream Hermes PR) tripped on. Two pinned IDs (`default_aux_model` and the README `model.default`) aren't covered by live fetch and would need a manual refresh if retired upstream; both exist in the live catalog today.

## Validation

Loaded the plugin against `NousResearch/hermes-agent` with a temp `HERMES_HOME`:

- Plugin registers; `neural-watt` / `neuralwatt-ai` aliases resolve to `neuralwatt`.
- `default_aux_model` is valid and present in `fallback_models`.
- `fetch_models()` live-returns the 11 current models (bare lowercase IDs).

`ruff check` + `ruff format --check` clean.

## Note on the upstream PR

There's an in-flight community PR ([NousResearch/hermes-agent#48383](https://github.com/NousResearch/hermes-agent/pull/48383)) adding Neuralwatt as a *built-in* provider; it currently carries the same stale/slash-form model IDs this PR corrects. This recipe plugin works today without waiting on that to merge, and the corrected catalog here can feed that PR.
